### PR TITLE
T695923: Update documentation for Nets

### DIFF
--- a/src/ansys/edb/core/layout_obj.py
+++ b/src/ansys/edb/core/layout_obj.py
@@ -70,11 +70,14 @@ class LayoutObj(ObjBase):
         Parameters
         ----------
         prod_id : :class:`ProductIdType <ansys.edb.database.ProductIdType>`
+            ID representing a product that supports the EDB.
         attr_id : int
+            A user-defined id that identifies the string value stored in the property
 
         Returns
         -------
         str
+            The string stored in this property.
         """
         return self.__stub.GetProductProperty(
             _QueryBuilder.get_product_property_type_msg(
@@ -88,8 +91,11 @@ class LayoutObj(ObjBase):
         Parameters
         ----------
         prod_id : :class:`ProductIdType <ansys.edb.database.ProductIdType>`
+            ID representing a product that supports the EDB.
         attr_id : int
+            A user-defined id that identifies the string value stored in the property
         prop_value : str
+            The string stored in this property.
         """
         self.__stub.SetProductProperty(
             _QueryBuilder.set_product_property_type_msg(
@@ -103,10 +109,12 @@ class LayoutObj(ObjBase):
         Parameters
         ----------
         prod_id : :class:`ProductIdType <ansys.edb.database.ProductIdType>`
+            ID representing a product that supports the EDB.
 
         Returns
         -------
         list[int]
+            List of the user-defined attribute IDs for properties stored in this object
         """
         attr_ids = self.__stub.GetProductPropertyIds(
             _QueryBuilder.get_product_property_ids_type_msg(self, prod_id, self.layout_obj_type)

--- a/src/ansys/edb/net/differential_pair.py
+++ b/src/ansys/edb/net/differential_pair.py
@@ -17,20 +17,23 @@ class DifferentialPair(NetClass):
     def create(cls, layout, name, pos_net=None, neg_net=None):
         """Create a differential pair.
 
+        User must either provide both nets or omit both nets
+
         Parameters
         ----------
         layout : :class:`Layout<ansys.edb.layout.Layout>`
-            Layout on which differential pair is placed.
+            Layout on which new differential pair is placed.
         name : str
-            Name of differential pair.
-        pos_net : :class:`Net<ansys.edb.net.Net>` or str, optional
-            Positive net. must be provided with negative net if non-None.
-        neg_net : :class:`Net<ansys.edb.net.Net>` or str, optional
-            Negative net. must be provided with positive net if non-None.
+            Name of new differential pair.
+        pos_net : Net or str, optional
+            Positive net or name of positive net.
+        neg_net : Net or str, optional
+            Negative net or name of negative net.
 
         Returns
         -------
         DifferentialPair
+            Newly created differential pair.
         """
         return cls(
             cls.__stub.Create(
@@ -39,93 +42,78 @@ class DifferentialPair(NetClass):
         )
 
     @classmethod
-    def find(cls, layout, name):
-        """Find a differential pair by name.
+    def find_by_name(cls, layout, name):
+        """Find a differential pair in a layout by name.
 
         Parameters
         ----------
         layout : :class:`Layout<ansys.edb.layout.Layout>`
+            Layout being searched for differential pair
         name : str
+            Name of the differential pair to find
 
         Returns
         -------
         DifferentialPair
+            The differential pair that was found. Check the returned differential pair's \
+            :obj:`is_null <ansys.edb.net.DifferentialPair.is_null>` property to see if it exists.
         """
         return cls(cls.__stub.FindByName(messages.string_property_message(layout, name)))
 
     @property
     def differential_pair(self):
-        """Get the differential pair.
-
-        Returns
-        -------
-        tuple(Net, Net)
-        """
+        r""":obj:`tuple`\(:class:`Net`, :class:`Net`\): The nets (positive, negative) in the differential pair."""
         msg = self.__stub.GetDifferentialPair(self.msg)
         return Net(msg.positive_net.id), Net(msg.negative_net.id)
 
     @differential_pair.setter
     def differential_pair(self, value):
-        """Set the differential pair (positive net, negative net)."""
         self.__stub.SetDifferentialPair(
             messages.differential_pair_net_refs_message(self, value[0], value[1])
         )
 
     @property
     def positive_net(self):
-        """Get the positive net of a differential pair.
-
-        Returns
-        -------
-        Net
-        """
+        """:class:`Net`: The positive net of a differential pair."""
         return self.differential_pair[0]
+
+    @positive_net.setter
+    def positive_net(self, value):
+        self.__stub.SetDifferentialPair(
+            messages.differential_pair_net_refs_message(self, value, self.differential_pair[1])
+        )
 
     @property
     def negative_net(self):
-        """Get the negative net of a differential pair.
-
-        Returns
-        -------
-        Net
-        """
+        """:class:`Net`: The negative net of a differential pair."""
         return self.differential_pair[1]
+
+    @negative_net.setter
+    def negative_net(self, value):
+        self.__stub.SetDifferentialPair(
+            messages.differential_pair_net_refs_message(self, self.differential_pair[0], value)
+        )
 
     @property
     def is_power_ground(self):
-        """Get if the differential pair is grounded.
-
-        Returns
-        -------
-        bool
-        """
+        """Invalid for differential pair."""
         return False
 
     def add_net(self, net):
-        """Add a net. this method is invalid for DifferentialPair.
+        """Invalid for differential pair.
 
-        Use differential_pair = (pos_net, neg_net) instead.
-
-        Parameters
-        ----------
-        net : Net
+        Use :obj:`ansys.edb.net.DifferentialPair.differential_pair` = (pos_net, neg_net) instead.
         """
         raise TypeError("net cannot be added to differential pair.")
 
     def remove_net(self, net):
-        """Remove a net. this method is invalid for DifferentialPair.
-
-        Use .differential_pair = (pos_net, neg_net) instead.
-
-        Parameters
-        ----------
-        net : Net
-        """
+        """Invalid for differential pair."""
         raise TypeError("net cannot be removed from differential pair.")
 
+    @property
     def nets(self):
-        """Get the list of nets. this method is invalid for DifferentialPair.
+        """Invalid for differential pair.
 
-        Use .differential_pair instead.
+        Use :obj:`ansys.edb.net.DifferentialPair.differential_pair` instead.
         """
-        raise TypeError("differential pairs do not have nets.")
+        return self.differential_pair

--- a/src/ansys/edb/net/extended_net.py
+++ b/src/ansys/edb/net/extended_net.py
@@ -28,19 +28,19 @@ class ExtendedNet(net_class.NetClass):
 
     @staticmethod
     def create(layout, name):
-        """Create an extendednet.
+        """Create an extended net.
 
         Parameters
         ----------
         layout : :class:`Layout <ansys.edb.layout.Layout>`
-            The layout object
+            Layout containing new extended net.
         name : str
-            Name of the extendednet to create
+            Name of the new extended net
 
         Returns
         -------
         ExtendedNet
-            Newly created extended netobject
+            Newly created extended net
         """
         return ExtendedNet(
             get_extended_net_stub().Create(_ExtendedNetQueryBuilder.extnet_create_msg(layout, name))
@@ -48,19 +48,20 @@ class ExtendedNet(net_class.NetClass):
 
     @staticmethod
     def find_by_name(layout, name):
-        """Find an extendednet in a layout by name.
+        """Find an extended net in a layout by name.
 
         Parameters
         ----------
         layout : :class:`Layout <ansys.edb.layout.Layout>`
-            The layout object
+            Layout being searched for extended net
         name : str
-            Name of the extendednet to find
+            Name of the extended net to find
 
         Returns
         -------
         ExtendedNet
-            The extended net that was found. Null object is returned if it is not found.
+            The extended net that was found. Check the returned extended net's \
+            :obj:`is_null <ansys.edb.net.ExtendedNet.is_null>` property to see if it exists.
         """
         return ExtendedNet(
             get_extended_net_stub().FindByName(
@@ -69,27 +70,25 @@ class ExtendedNet(net_class.NetClass):
         )
 
     def add_net(self, net):
-        """Add net to an extendednet.
+        """Add net to this extended net.
 
         Parameters
         ----------
-        net : :class:`Net <ansys.edb.layout.Net>`
-            The net object to be added
-
+        net : Net
+            The net to be added.
         """
         self.__stub.AddNet(_ExtendedNetQueryBuilder.extnet_modify_net_msg(self, net))
 
     def remove_net(self, net):
-        """Remove net from extendednet.
+        """Remove net from this extended net.
 
         Parameters
         ----------
-        net : :class:`Net <ansys.edb.layout.Net>`
-            The net object to be removed
-
+        net : Net
+            The net to be removed.
         """
         self.__stub.RemoveNet(_ExtendedNetQueryBuilder.extnet_modify_net_msg(self, net))
 
     def remove_all_nets(self):
-        """Remove all nets from extendednet."""
+        """Remove all nets from this extended net."""
         self.__stub.RemoveAllNets(self.msg)

--- a/src/ansys/edb/net/net.py
+++ b/src/ansys/edb/net/net.py
@@ -27,11 +27,14 @@ class Net(layout_obj.LayoutObj):
         Parameters
         ----------
         layout : :class:`Layout <ansys.edb.layout.Layout>`
+            Layout containing new net.
         name : str
+            Name of new net
 
         Returns
         -------
         Net
+            Newly created net.
         """
         return Net(cls.__stub.Create(messages.string_property_message(layout, name)))
 
@@ -42,101 +45,87 @@ class Net(layout_obj.LayoutObj):
         Parameters
         ----------
         layout : :class:`Layout <ansys.edb.layout.Layout>`
+            Layout being searched for net
         name : str
+            Name of net being searched for.
 
         Returns
         -------
         Net
+            Net matching the requested name. Check the returned net's \
+            :obj:`is_null <ansys.edb.net.Net.is_null>` property to see if it exists.
         """
         return Net(cls.__stub.FindByName(messages.string_property_message(layout, name)))
 
     @property
     def name(self):
-        """Get name of a net.
-
-        Returns
-        -------
-        str
-        """
+        """:class:`str`: Name of this net."""
         return self.__stub.GetName(self.msg).value
 
     @name.setter
     def name(self, value):
-        """Set name of a net."""
         self.__stub.SetName(messages.string_property_message(self, value))
 
     @property
     def is_power_ground(self):
-        """Get whether a net is grounded.
+        """:class:`bool`: True if net belongs to Power/Ground :class:`NetClass`.
 
-        Returns
-        -------
-        bool
+        Read-Only.
         """
         return self.__stub.GetIsPowerGround(self.msg).value
 
     @is_power_ground.setter
     def is_power_ground(self, value):
-        """Set if a net is grounded."""
         self.__stub.SetIsPowerGround(messages.bool_property_message(self, value))
 
     @property
     def primitives(self):
-        """Get a list of primitives on a net.
+        r""":obj:`list`\[:class:`Primitive <ansys.edb.primitive.Primitive>`\]: List of all primitives on this net.
 
-        Returns
-        -------
-        list[:class:`Primitive <ansys.edb.primitive.Primitive>`]
+        Read-Only.
         """
         return [Primitive(lo).cast() for lo in self._layout_objs(LayoutObjType.PRIMITIVE)]
 
     @property
     def padstack_instances(self):
-        """Get a list of padstack instances on a net.
+        r"""
+        :obj:`list`\[:class:`PadstackInstance <ansys.edb.primitive.PadstackInstance>`\]: List of padstacks on this net.
 
-        Returns
-        -------
-        list[:class:`PadstackInstance <ansys.edb.primitive.PadstackInstance>`]
+        Read-Only.
         """
         return [PadstackInstance(lo) for lo in self._layout_objs(LayoutObjType.PADSTACK_INSTANCE)]
 
     @property
     def terminals(self):
-        """Get a list of terminals on a net.
+        r""":obj:`list`\[:class:`Terminal <ansys.edb.terminal.Terminal>`\]: List of all terminals on this net.
 
-        Returns
-        -------
-        list[:class:`Terminal <ansys.edb.terminal.Terminal>`]
+        Read-Only.
         """
         return [Terminal(lo).cast() for lo in self._layout_objs(LayoutObjType.TERMINAL)]
 
     @property
     def terminal_instances(self):
-        """Get a list of terminal instances on a net.
+        r""":obj:`list`\[:class:`TerminalInstance <ansys.edb.terminal.TerminalInstance>`\]: terminal instances on net.
 
-        Returns
-        -------
-        list[:class:`TerminalInstance <ansys.edb.terminal.TerminalInstance>`]
+        Read-Only.
         """
         return [TerminalInstance(lo) for lo in self._layout_objs(LayoutObjType.TERMINAL_INSTANCE)]
 
     @property
     def net_classes(self):
-        """Get a list of net classes on a net.
+        r""":obj:`list`\[:class:`NetClass`\]: List of all net classes on this net.
 
-        Returns
-        -------
-        list[:class:`NetClass <ansys.edb.net.NetClass>`]
+        Read-Only.
         """
         return [NetClass(lo) for lo in self._layout_objs(LayoutObjType.NET_CLASS)]
 
     @property
     def extended_net(self):
-        """Get an extended net.
+        """:class:`ExtendedNet` or :class:`None`: The extended net that this net belongs to.
 
-        Returns
-        -------
-        :class:`ExtendedNet <ansys.edb.net.ExtendedNet>`
+        :class:`None` means the net doesn't belong to an extended net.
+
+        Read-Only.
         """
         en = ExtendedNet(self._layout_objs(LayoutObjType.NET_CLASS)[0])
         return None if en.is_null else en

--- a/src/ansys/edb/net/net_class.py
+++ b/src/ansys/edb/net/net_class.py
@@ -26,84 +26,61 @@ class NetClass(layout_obj.LayoutObj):
 
         Parameters
         ----------
-        layout : Layout
+        layout : :class:`Layout <ansys.edb.layout.Layout>`
+            Layout containing new net class.
         name : str
+            Name of the new net class.
 
         Returns
         -------
         NetClass
+            Newly created net class.
         """
         return NetClass(cls.__stub.Create(_QueryBuilder.create(layout, name)))
 
     @classmethod
-    def find(cls, layout, name):
+    def find_by_name(cls, layout, name):
         """
         Find net class by name.
 
         Parameters
         ----------
-        layout : Layout
+        layout : :class:`Layout <ansys.edb.layout.Layout>`
+            Layout being searched for net class.
         name : str
+            Name of net class being searched for.
 
         Returns
         -------
         NetClass
+            Net class matching the requested name. Check the returned net class's \
+            :obj:`is_null <ansys.edb.net.NetClass.is_null>` property to see if it exists.
         """
         return NetClass(cls.__stub.FindByName(messages.edb_obj_name_message(layout, name)))
 
     @property
     def name(self):
-        """
-        Name of net class.
-
-        Returns
-        -------
-        str
-        """
+        """:obj:`str`: Name of this object."""
         return self.__stub.GetName(self.msg).value
 
     @name.setter
     def name(self, newname):
-        """
-        Set name of net class.
-
-        Parameters
-        ----------
-        newname : str
-
-        """
         self.__stub.SetName(messages.edb_obj_name_message(self.msg, newname))
 
     @property
     def description(self):
-        """
-        Return description of net class.
-
-        Returns
-        -------
-        str
-        """
+        """:obj:`str` : Description of this object."""
         return self.__stub.GetDescription(self.msg).value
 
     @description.setter
     def description(self, newdesc):
-        """
-        Set description of net class.
-
-        Parameters
-        ----------
-        newdesc : str
-
-        """
         self.__stub.SetDescription(messages.string_property_message(self, newdesc))
 
     @property
     def is_power_ground(self):
-        """Return whether this netclass is power or ground.
+        """:class:`bool`: True if object belongs to Power/Ground :class:`NetClass`.
 
-        Returns
-        -------
-        bool
+        Read-Only.
         """
         return self.__stub.IsPowerGround(messages.edb_obj_message(self.msg)).value
 
@@ -120,37 +97,39 @@ class NetClass(layout_obj.LayoutObj):
 
     def add_net(self, net):
         """
-        Add net to netclass.
+        Add net to this this object.
 
         Parameters
         ----------
         net : Net
-
+            Net to add
         """
         return self.__stub.AddNet(nc_pb2.NetClassEditMessage(netclass=self.msg, net=net.msg))
 
     def remove_net(self, net):
         """
-        Remove net from netclass.
+        Remove net from this object.
 
         Parameters
         ----------
         net : Net
-
+            Net to remove
         """
         self.__stub.RemoveNet(nc_pb2.NetClassEditMessage(netclass=self.msg, net=net.msg))
 
     def contains_net(self, net):
         """
-        Find if net exists in netclass.
+        Check if net exists in this object.
 
         Parameters
         ----------
         net : Net
+            Net to check for.
 
         Returns
         -------
         bool
+            True if net is in this object
         """
         return self.__stub.ContainsNet(
             nc_pb2.NetClassEditMessage(netclass=self.msg, net=net.msg)


### PR DESCRIPTION
Can someone help me in the docstring for Net:TerminalInstances? If I substitute terminal instances for TIs, the line is too long. However if I add a backslash to continue the text on the next line, it won't pass the doc style check.