### PR TITLE
D177: Remove double quotes from GH action pattern match

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -3,10 +3,10 @@ on:
   pull_request:
   push:
     tags:
-      - "*"
+      - '*'
     branches:
       - develop
-      - "release-*"
+      - release-*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
fix #177 

seems like github unofficially only supports single quotes. let's give it a try with this