### PR TITLE
D187: Sync proto files from release-23.1

### DIFF
--- a/protos/ansys/api/edb/v1/bondwire_def.proto
+++ b/protos/ansys/api/edb/v1/bondwire_def.proto
@@ -36,7 +36,7 @@ service ApdBondwireDefService {
 
   // Find Apd BondwireDef By Name.
   rpc FindByName (BondwireDefStrMessage) returns (EDBObjMessage) {}
-
+  
   // Get Apd BondwireDef parameters in cblock string format.
   rpc GetParameters (EDBObjMessage) returns (google.protobuf.StringValue) {}
 
@@ -47,13 +47,13 @@ service ApdBondwireDefService {
 service Jedec4BondwireDefService {
   // Creates an Jedec4BondwireDef.
   rpc Create (BondwireDefStrMessage) returns (EDBObjMessage) {}
-
+  
   // Find Jedec4BondwireDef By Name.
   rpc FindByName (BondwireDefStrMessage) returns (EDBObjMessage) {}
-
+  
   // Get Jedec4BondwireDef parameters in cblock string format.
   rpc GetParameters (EDBObjMessage) returns (ValueMessage) {}
-
+  
   // Set Jedec4BondwireDef parameters by passing cblock string.
   rpc SetParameters (Jedec4BondwireDefSetParametersMessage) returns (google.protobuf.Empty) {}
 }
@@ -66,13 +66,13 @@ message Jedec4BondwireDefSetParametersMessage{
 service Jedec5BondwireDefService {
   // Creates an Jedec5BondwireDef.
   rpc Create (BondwireDefStrMessage) returns (EDBObjMessage) {}
-
+  
   // Find Jedec5BondwireDef By Name.
   rpc FindByName (BondwireDefStrMessage) returns (EDBObjMessage) {}
-
+  
   // Get Jedec5BondwireDef parameters in cblock string format.
   rpc GetParameters (EDBObjMessage) returns (Jedec5BondwireDefParametersMessage) {}
-
+  
   // Set Jedec5BondwireDef parameters by passing cblock string.
   rpc SetParameters (Jedec5BondwireDefSetParametersMessage) returns (google.protobuf.Empty) {}
 }

--- a/protos/ansys/api/edb/v1/connectable.proto
+++ b/protos/ansys/api/edb/v1/connectable.proto
@@ -12,6 +12,7 @@ import "layout_obj.proto";
 
 // Connectable Service definition
 service ConnectableService {
+
   // Gets the layout object type.
   rpc GetObjType(EDBObjMessage) returns (LayoutObjTypeMessage) {}
 

--- a/protos/ansys/api/edb/v1/layer_collection.proto
+++ b/protos/ansys/api/edb/v1/layer_collection.proto
@@ -5,7 +5,6 @@ syntax = "proto3";
 package ansys.api.edb.v1;
 
 import "edb_messages.proto";
-import "database.proto";
 import "layer.proto";
 
 enum LayerCollectionMode {
@@ -108,7 +107,7 @@ message AddLayerMessage {
   EDBObjMessage layer = 2;
   oneof op_params {
     AddLayerAboveBelowMessage above_below_msg = 3;
-	  bool add_top = 4;
+	bool add_top = 4;
   }
 }
 

--- a/protos/ansys/api/edb/v1/layer_map.proto
+++ b/protos/ansys/api/edb/v1/layer_map.proto
@@ -38,6 +38,6 @@ message LayerMapUniqueDirectionMessage {
 
 message LayerMapTwoIntPropertiesMessage {
   EDBObjMessage target = 1;
-  uint64 from_id = 2;
-  uint64 to_id = 3;
+  EDBInternalIdMessage from_id = 2;
+  EDBInternalIdMessage to_id = 3;
 }

--- a/protos/ansys/api/edb/v1/layout_instance.proto
+++ b/protos/ansys/api/edb/v1/layout_instance.proto
@@ -23,7 +23,7 @@ message LayoutObjInstancesQueryMessage {
   EDBObjMessage layout_inst = 1;
   oneof spatial_filter {
     PointMessage point_filter = 2;
-	  PolygonDataMessage region_filter = 3;
+    PolygonDataMessage region_filter = 3;
   }
   repeated LayerRefMessage layer_filter = 4;
   repeated NetRefMessage net_filter = 5;
@@ -32,7 +32,7 @@ message LayoutObjInstancesQueryMessage {
 message LayoutObjInstancesQueryResultsMessage {
   oneof results {
     EDBObjCollectionMessage hits = 1;
-    FullPartialHitsMessage full_partial_hits = 2;
+	FullPartialHitsMessage full_partial_hits = 2;
   }
 }
 

--- a/protos/ansys/api/edb/v1/layout_obj.proto
+++ b/protos/ansys/api/edb/v1/layout_obj.proto
@@ -5,7 +5,6 @@ syntax = "proto3";
 package ansys.api.edb.v1;
 
 import "edb_messages.proto";
-import "refs.proto";
 
 // Enum for layout object types
 enum LayoutObjType {
@@ -30,9 +29,6 @@ enum LayoutObjType {
 
 // LayoutObj service definition
 service LayoutObjService {
-  // Gets the layout object type
-  rpc GetObjType (EDBObjMessage) returns (EDBObjMessage) {}
-
   // Gets the layout of the layout object
   rpc GetLayout (LayoutObjTargetMessage) returns (EDBObjMessage) {}
   

--- a/protos/ansys/api/edb/v1/material_def.proto
+++ b/protos/ansys/api/edb/v1/material_def.proto
@@ -32,13 +32,13 @@ service MaterialDefService {
 
   // Find Material Definition by name
   rpc FindByName(EDBObjNameMessage) returns (EDBObjMessage) {}
-
+  
   // Delete Material Definition
   rpc Delete(EDBObjMessage) returns (google.protobuf.Empty) {}
-
+  
   // Get Property
   rpc GetProperty(MaterialDefGetPropertyMessage) returns (ValueMessage) {}
-
+  
   // Get All Properties
   rpc GetAllProperties(EDBObjMessage) returns (MaterialDefGetAllPropertiesMessage) {}
 
@@ -47,26 +47,26 @@ service MaterialDefService {
 
   // Get Name of Material Def
   rpc GetName(EDBObjMessage) returns (google.protobuf.StringValue) {}
-
+  
   // Get Dielectric Material Model
   rpc GetDielectricMaterialModel(EDBObjMessage) returns (EDBObjMessage) {}
-
-  // Set Dielectric Material Model
+  
+  // Set Dielectric Material Model 
   rpc SetDielectricMaterialModel(PointerPropertyMessage) returns (google.protobuf.Empty) {}
 
   // Get Dimensions
   rpc GetDimensions(MaterialDefPropertyMessage) returns (MaterialDefGetDimensionMessage) {}
-
+  
   // Set Thermal Modifier
   rpc SetThermalModifier(SetMaterialDefPropertyMessage) returns (google.protobuf.Empty) {}
 
   // Set Anisotropic Thermal Modifier
   rpc SetAnisotropicThermalModifier(SetMaterialDefPropertyComponentMessage) returns (google.protobuf.Empty) {}
-
+  
   // Get Thermal Modifier
   rpc GetThermalModifier(MaterialDefPropertyMessage) returns (EDBObjMessage) {}
-
-  // Get Anisotropic Thermal Modifier
+  
+  // Get Anisotropic Thermal Modifier 
   rpc GetAnisotropicThermalModifier(MaterialDefPropertyComponentMessage) returns (EDBObjMessage) {}
 }
 

--- a/protos/ansys/api/edb/v1/netclass.proto
+++ b/protos/ansys/api/edb/v1/netclass.proto
@@ -8,7 +8,7 @@ import "edb_messages.proto";
 
 service NetClassService {
   rpc Create(NetClassCreationMessage) returns (EDBObjMessage) {}
-
+  
   rpc FindByName(EDBObjNameMessage) returns (EDBObjMessage) {}
 
   rpc GetName(EDBObjMessage) returns (google.protobuf.StringValue) {}
@@ -20,9 +20,9 @@ service NetClassService {
   rpc SetDescription(StringPropertyMessage) returns (google.protobuf.Empty) {}
 
   rpc IsPowerGround(EDBObjMessage) returns (google.protobuf.BoolValue) {}
-
+  
   rpc GetNets(EDBObjMessage) returns (EDBObjCollectionMessage) {}
-
+  
   rpc AddNet(NetClassEditMessage) returns (google.protobuf.Empty) {}
 
   rpc RemoveNet(NetClassEditMessage) returns (google.protobuf.Empty) {}

--- a/protos/ansys/api/edb/v1/padstack_def.proto
+++ b/protos/ansys/api/edb/v1/padstack_def.proto
@@ -7,7 +7,7 @@ import "edb_messages.proto";
 service PadstackDefService {
   // create a PadstackDef
   rpc Create(PadstackDefStringMessage) returns (EDBObjMessage) {}
-
+  
   // delete a PadstackDef
   rpc Delete(EDBObjMessage) returns (google.protobuf.Empty) {}
 

--- a/protos/ansys/api/edb/v1/padstack_def_data.proto
+++ b/protos/ansys/api/edb/v1/padstack_def_data.proto
@@ -179,15 +179,15 @@ message PadstackDefDataSetPolygonalPadParametersMessage{
 
 message PadstackDefDataPadParametersMessage{
   oneof pad_message {
-	  PadstackDefDataGetPadParametersParametersMessage generic = 1;
-	  PadstackDefDataGetPolygonalPadParametersParametersMessage polygon = 2;
+    PadstackDefDataGetPadParametersParametersMessage generic = 1;
+    PadstackDefDataGetPolygonalPadParametersParametersMessage polygon = 2;
   }
 }
 
 message PadstackDefDataPadParametersSetMessage{
   oneof pad_message {
-	  PadstackDefDataSetPadParametersMessage generic = 1;
-	  PadstackDefDataSetPolygonalPadParametersMessage polygon = 2;
+    PadstackDefDataSetPadParametersMessage generic = 1;
+    PadstackDefDataSetPolygonalPadParametersMessage polygon = 2;
   }
 }
 

--- a/protos/ansys/api/edb/v1/padstack_instance.proto
+++ b/protos/ansys/api/edb/v1/padstack_instance.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package ansys.api.edb.v1;
 
 import "edb_messages.proto";
-//import "point_data.proto";
+import "point_data.proto";
 
 // BACK_DRILL_TYPE type enum
 enum BackDrillType {
@@ -23,7 +23,7 @@ service PadstackInstanceService {
   rpc GetName(EDBObjMessage) returns (google.protobuf.StringValue) {}
 
   // Set name of PadstackInst
-  rpc SetName(PadstackInstSetNameMessage) returns (google.protobuf.Empty) {}
+  rpc SetName(EDBObjNameMessage) returns (google.protobuf.Empty) {}
   
   // Get position and rotation from PadstackInst
   rpc GetPositionAndRotation(EDBObjMessage) returns (PadstackInstPositionAndRotationMessage) {}
@@ -48,40 +48,40 @@ service PadstackInstanceService {
   
   // Set Layer Map from PadstackInst
   rpc SetLayerMap(PointerPropertyMessage) returns (google.protobuf.Empty) {}
-
+  
   // Get Hole Overrides from PadstackInst
   rpc GetHoleOverrides(EDBObjMessage) returns (PadstackInstHoleOverridesMessage) {}
-
+  
   // Set Hole Overrides of PadstackInst
   rpc SetHoleOverrides(PadstackInstSetHoleOverridesMessage) returns (google.protobuf.Empty) {}
-
+  
   // Check if PadstackInst is layout pin
   rpc GetIsLayoutPin(EDBObjMessage) returns (google.protobuf.BoolValue) {}
-
+  
   // Set PadstackInst to be layout pin
   rpc SetIsLayoutPin(PadstackInstSetIsLayoutPinMessage) returns (google.protobuf.Empty) {}
-
+  
   // Get Back Drill Type from PadstackInst
   rpc GetBackDrillType(PadstackInstGetBackDrillMessage) returns (PadstackInstBackDrillTypeMessage) {}
-
+  
   // Get back drill by layer from PadstackInst
   rpc GetBackDrillByLayer(PadstackInstGetBackDrillMessage) returns (PadstackInstBackDrillByLayerMessage) {}
-
+  
   // Get back drill by depth from PadstackInst
   rpc GetBackDrillByDepth(PadstackInstGetBackDrillMessage) returns (PadstackInstBackDrillByDepthMessage) {}
-
+  
   // Set back drill of PadstackInst by layer by Layer
   rpc SetBackDrillByLayer(PadstackInstSetBackDrillByLayerMessage) returns (google.protobuf.Empty) {}
-
+  
   // Set back drill of PadstackInst by layer by Depth
   rpc SetBackDrillByDepth(PadstackInstSetBackDrillByDepthMessage) returns (google.protobuf.Empty) {}
-
+  
   // Get Terminal of PadstackInst
   rpc GetPadstackInstanceTerminal(EDBObjMessage) returns (EDBObjMessage) {}
-
+  
   // Check if PadstackInst is in pin group
   rpc IsInPinGroup(PadstackInstIsInPinGroupMessage) returns (google.protobuf.BoolValue) {}
-
+  
   // Get pin groups of PadstackInst
   rpc GetPinGroups(EDBObjMessage) returns (EDBObjCollectionMessage ) {}
 
@@ -99,15 +99,9 @@ message PadstackInstCreateMessage{
   EDBObjMessage layer_map = 9;
 }
 
-message PadstackInstSetNameMessage {
-  EDBObjMessage target = 1;
-  string name = 2;
-}
-
 message PadstackInstPositionAndRotationMessage {
-  ValueMessage x = 1;
-  ValueMessage y = 2;
-  ValueMessage rotation = 3;
+  PointMessage position = 1;
+  ValueMessage rotation = 2;
 }
 
 message PadstackInstSetPositionAndRotationMessage {

--- a/protos/ansys/api/edb/v1/primitive.proto
+++ b/protos/ansys/api/edb/v1/primitive.proto
@@ -36,16 +36,16 @@ service PrimitiveService {
 
   // Get Layer
   rpc GetLayer (EDBObjMessage) returns (EDBObjMessage) {}
-
+  
   // Set Layer
   rpc SetLayer (SetLayerMessage) returns (google.protobuf.Empty) {}
 
   // Get IsNegative
   rpc GetIsNegative (EDBObjMessage) returns (google.protobuf.BoolValue) {}
-
+  
   // Set IsNegative
   rpc SetIsNegative (SetIsNegativeMessage) returns (google.protobuf.Empty) {}
-
+  
   // Get isVoid
   rpc IsVoid (EDBObjMessage) returns (google.protobuf.BoolValue) {}
 

--- a/protos/ansys/api/edb/v1/solder_ball_property.proto
+++ b/protos/ansys/api/edb/v1/solder_ball_property.proto
@@ -7,7 +7,7 @@ import "padstack_def_data.proto";
 
 service SolderBallPropertyService {
   rpc Create(google.protobuf.Empty) returns (EDBObjMessage) {}
-
+  
   rpc GetShape(EDBObjMessage) returns (PadstackDefDataSolderballShapeMessage) {}
   rpc SetShape(PadstackDefDataSetSolderballShapeMessage) returns (google.protobuf.Empty) {}
 

--- a/protos/ansys/api/edb/v1/voltage_regulator.proto
+++ b/protos/ansys/api/edb/v1/voltage_regulator.proto
@@ -5,6 +5,7 @@ syntax = "proto3";
 package ansys.api.edb.v1;
 
 import "edb_messages.proto";
+import "refs.proto";
 
 service VoltageRegulatorService {
   rpc Create (VoltageRegulatorMessage) returns (EDBObjMessage) {}

--- a/src/ansys/edb/core/messages.py
+++ b/src/ansys/edb/core/messages.py
@@ -260,7 +260,7 @@ def polygon_data_remove_arc_message(pd, max_chord_error, max_arc_angle, max_poin
 
 
 def polygon_data_with_circle_message(pd, center, radius):
-    """Convert to PolygonDataDoesIntersectMessage."""
+    """Convert to PolygonDataWithCircleMessage."""
     return PolygonDataWithCircleMessage(
         polygon=polygon_data_message(pd), circle=circle_message(center, radius)
     )

--- a/src/ansys/edb/primitive/primitive.py
+++ b/src/ansys/edb/primitive/primitive.py
@@ -1491,16 +1491,12 @@ class _PadstackInstanceQueryBuilder:
 
     @staticmethod
     def set_name_message(padstack_inst, name):
-        return padstack_instance_pb2.PadstackInstSetNameMessage(
-            target=padstack_inst.msg,
-            name=name,
-        )
+        return messages.edb_obj_name_message(padstack_inst, name)
 
     @staticmethod
     def position_and_rotation_message(x, y, rotation):
         return padstack_instance_pb2.PadstackInstPositionAndRotationMessage(
-            x=messages.value_message(x),
-            y=messages.value_message(y),
+            position=messages.point_message((x, y)),
             rotation=messages.value_message(rotation),
         )
 

--- a/src/ansys/edb/utility/layer_map.py
+++ b/src/ansys/edb/utility/layer_map.py
@@ -33,8 +33,8 @@ class _QueryBuilder:
         """
         return pb.LayerMapTwoIntPropertiesMessage(
             target=target,
-            from_id=from_id,
-            to_id=to_id,
+            from_id=messages.edb_internal_id_message(from_id),
+            to_id=messages.edb_internal_id_message(to_id),
         )
 
 


### PR DESCRIPTION
Porting all proto changes from release-23.1 server that is out of sync on the client.
Keeping all format identical from server side protos (including whitespaces and such) to be consistent and to be able distinguish difference easily

needs to be cherry picked onto release-23.1 branch

fixes #187 