### PR TITLE
D192: Change source import for flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,8 +20,8 @@ repos:
         ^protos
       )
 
-- repo: https://gitlab.com/PyCQA/flake8
-  rev: 4.0.1
+- repo: https://github.com/PyCQA/flake8
+  rev: 5.0.4
   hooks:
   - id: flake8
     exclude: |


### PR DESCRIPTION
As title says. This is the recommended source for flake8 for PyAnsys libraries.

resolves #192 