### PR TITLE
S641096: Add definition base method

### DIFF
--- a/doc/source/api/definition.rst
+++ b/doc/source/api/definition.rst
@@ -30,7 +30,7 @@ Classes
    ICComponentProperty
    DieProperty
    PortProperty
-   
+
 
 Enums
 -----
@@ -38,6 +38,7 @@ Enums
 .. autosummary::
    :toctree: _autosummary
 
+   DefinitionObjType
    BondwireDefType
    MaterialProperty
    PadType
@@ -47,4 +48,3 @@ Enums
    SolderballPlacement
    DieType
    DieOrientation
-

--- a/doc/source/api/index.rst
+++ b/doc/source/api/index.rst
@@ -31,8 +31,3 @@ Modules
    terminal
    utility
    release_notes
-   
-
-
-
-

--- a/src/ansys/edb/definition/__init__.py
+++ b/src/ansys/edb/definition/__init__.py
@@ -39,3 +39,4 @@ from ansys.edb.definition.padstack_def_data import (
 )
 from ansys.edb.definition.port_property import PortProperty
 from ansys.edb.definition.solder_ball_property import SolderBallProperty
+from ansys.edb.edb_defs import DefinitionObjType

--- a/src/ansys/edb/definition/bondwire_def.py
+++ b/src/ansys/edb/definition/bondwire_def.py
@@ -6,6 +6,7 @@ from ansys.api.edb.v1 import bondwire_def_pb2_grpc
 import ansys.api.edb.v1.bondwire_def_pb2 as pb
 
 from ansys.edb.core import ObjBase, messages
+from ansys.edb.edb_defs import DefinitionObjType
 from ansys.edb.session import StubAccessor, StubType
 from ansys.edb.utility import Value
 
@@ -64,9 +65,10 @@ class BondwireDef(ObjBase):
 
     __stub: bondwire_def_pb2_grpc.BondwireDefServiceStub = StubAccessor(StubType.bondwire_def)
 
-    def delete(self):
-        """Delete a bondwire definition."""
-        self.__stub.Delete(self.msg)
+    @property
+    def definition_type(self):
+        """:class:`DefinitionObjType`: type."""
+        return DefinitionObjType.BONDWIRE_DEF
 
     @property
     def name(self):
@@ -75,6 +77,10 @@ class BondwireDef(ObjBase):
         Read-Only.
         """
         return self.__stub.GetName(self.msg)
+
+    def delete(self):
+        """Delete a bondwire definition."""
+        self.__stub.Delete(self.msg)
 
 
 class ApdBondwireDef(BondwireDef):
@@ -174,7 +180,7 @@ class _Jedec4QueryBuilder:
         )
 
 
-class Jedec4BondwireDef(ObjBase):
+class Jedec4BondwireDef(BondwireDef):
     """Class representing a jedec 4 bondwire definition."""
 
     __stub: bondwire_def_pb2_grpc.Jedec4BondwireDefServiceStub = StubAccessor(

--- a/src/ansys/edb/definition/component_def.py
+++ b/src/ansys/edb/definition/component_def.py
@@ -4,6 +4,7 @@ from ansys.api.edb.v1.component_def_pb2_grpc import ComponentDefServiceStub
 from ansys.edb.core import ObjBase, messages
 from ansys.edb.core.utils import map_list
 from ansys.edb.definition import component_model, component_pin
+from ansys.edb.edb_defs import DefinitionObjType
 from ansys.edb.layout import cell
 from ansys.edb.session import StubAccessor, StubType
 
@@ -54,6 +55,11 @@ class ComponentDef(ObjBase):
         return ComponentDef(
             cls.__stub.FindByName(messages.object_name_in_layout_message(db, comp_def_name))
         )
+
+    @property
+    def definition_type(self):
+        """:class:`DefinitionObjType`: type."""
+        return DefinitionObjType.COMPONENT_DEF
 
     @property
     def name(self):

--- a/src/ansys/edb/definition/dataset_def.py
+++ b/src/ansys/edb/definition/dataset_def.py
@@ -9,6 +9,7 @@ from ansys.edb.core.messages import (
     string_property_message,
 )
 from ansys.edb.core.parser import to_point_data_list
+from ansys.edb.edb_defs import DefinitionObjType
 from ansys.edb.session import StubAccessor, StubType
 
 
@@ -53,6 +54,11 @@ class DatasetDef(ObjBase):
             If a dataset isn't found then dataset's is_null will result True.
         """
         return DatasetDef(cls.__stub.FindByName(edb_obj_name_message(database, name)))
+
+    @property
+    def definition_type(self):
+        """:class:`DefinitionObjType`: type."""
+        return DefinitionObjType.DATASET_DEF
 
     @property
     def name(self):

--- a/src/ansys/edb/definition/material_def.py
+++ b/src/ansys/edb/definition/material_def.py
@@ -6,6 +6,7 @@ import ansys.api.edb.v1.material_def_pb2 as pb
 
 from ansys.edb.core import ObjBase, messages
 from ansys.edb.definition import DielectricMaterialModel
+from ansys.edb.edb_defs import DefinitionObjType
 from ansys.edb.session import MaterialDefServiceStub, StubAccessor, StubType
 from ansys.edb.utility import Value
 
@@ -194,6 +195,31 @@ class MaterialDef(ObjBase):
         """
         return MaterialDef(cls.__stub.FindByName(messages.edb_obj_name_message(database, name)))
 
+    @property
+    def definition_type(self):
+        """:class:`DefinitionObjType`: type."""
+        return DefinitionObjType.MATERIAL_DEF
+
+    @property
+    def name(self):
+        """:obj:`str`: Name of the material definition.
+
+        Read-Only.
+        """
+        return self.__stub.GetName(messages.edb_obj_message(self)).value
+
+    @property
+    def dielectric_material_model(self):
+        """:class:`DielectricMaterialModel <ansys.edb.definition.dielectric_material_model.DielectricMaterialModel>`: \
+        Dielectric material model of the material definition."""
+        return DielectricMaterialModel(
+            self.__stub.GetDielectricMaterialModel(messages.edb_obj_message(self))
+        )
+
+    @dielectric_material_model.setter
+    def dielectric_material_model(self, dielectric):
+        self.__stub.SetDielectricMaterialModel(messages.pointer_property_message(self, dielectric))
+
     def delete(self):
         """Delete a material definition."""
         self.__stub.Delete(messages.edb_obj_message(self))
@@ -267,26 +293,6 @@ class MaterialDef(ObjBase):
                 messages.edb_obj_message(self), material_property, None, None, None
             )
         )
-
-    @property
-    def name(self):
-        """:obj:`str`: Name of the material definition.
-
-        Read-Only.
-        """
-        return self.__stub.GetName(messages.edb_obj_message(self)).value
-
-    @property
-    def dielectric_material_model(self):
-        """:class:`DielectricMaterialModel <ansys.edb.definition.dielectric_material_model.DielectricMaterialModel>`: \
-        Dielectric material model of the material definition."""
-        return DielectricMaterialModel(
-            self.__stub.GetDielectricMaterialModel(messages.edb_obj_message(self))
-        )
-
-    @dielectric_material_model.setter
-    def dielectric_material_model(self, dielectric):
-        self.__stub.SetDielectricMaterialModel(messages.pointer_property_message(self, dielectric))
 
     def get_dimensions(self, material_property_id):
         """Get dimensions of a material definition Simple 1x1, Anisotropic 3x1, Tensor 3x3.

--- a/src/ansys/edb/definition/package_def.py
+++ b/src/ansys/edb/definition/package_def.py
@@ -15,6 +15,7 @@ from ansys.edb.core.messages import (
     value_message,
     value_property_message,
 )
+from ansys.edb.edb_defs import DefinitionObjType
 from ansys.edb.session import StubAccessor, StubType
 from ansys.edb.utility import Value
 from ansys.edb.utility.heat_sink import HeatSink, HeatSinkFinOrientation
@@ -42,29 +43,30 @@ class PackageDef(ObjBase):
         """
         return PackageDef(cls.__stub.Create(string_property_message(db, name)))
 
-    def delete(self):
-        """Delete the Package definition."""
-        self.__stub.Delete(edb_obj_message(self))
-
     @classmethod
-    def find_by_name(cls, self, name):
+    def find_by_name(cls, db, name):
         """Find a Package definition object by name.
 
         Returns
         -------
         PackageDef
         """
-        return PackageDef(cls.__stub.FindByName(string_property_message(self, name)))
+        return PackageDef(cls.__stub.FindByName(string_property_message(db, name)))
 
     @classmethod
-    def find_by_id(cls, self, uid):
+    def find_by_id(cls, db, uid):
         """Find a Package definition object by Id.
 
         Returns
         -------
         PackageDef
         """
-        return PackageDef(cls.__stub.FindByEDBUId(int_property_message(self, uid)))
+        return PackageDef(cls.__stub.FindByEDBUId(int_property_message(db, uid)))
+
+    @property
+    def definition_type(self):
+        """:class:`DefinitionObjType`: type."""
+        return DefinitionObjType.PACKAGE_DEF
 
     @property
     def name(self):
@@ -154,6 +156,10 @@ class PackageDef(ObjBase):
     @heat_sink.setter
     def heat_sink(self, heat_sink_value):
         self.__stub.SetHeatSink(set_heat_sink_message(self, heat_sink_value))
+
+    def delete(self):
+        """Delete the Package definition."""
+        self.__stub.Delete(edb_obj_message(self))
 
     def get_product_property(self, prod_id, attr_it):
         """Get the product-specific property value.

--- a/src/ansys/edb/definition/padstack_def.py
+++ b/src/ansys/edb/definition/padstack_def.py
@@ -5,6 +5,7 @@ import ansys.api.edb.v1.padstack_def_pb2 as pb
 
 from ansys.edb.core import ObjBase
 from ansys.edb.definition.padstack_def_data import PadstackDefData
+from ansys.edb.edb_defs import DefinitionObjType
 from ansys.edb.session import StubAccessor, StubType
 
 
@@ -69,10 +70,6 @@ class PadstackDef(ObjBase):
             cls.__stub.Create(_PadstackDefQueryBuilder.padstack_def_string_message(db, name))
         )
 
-    def delete(self):
-        """Delete a PadstackDef."""
-        self.__stub.Delete(self.msg)
-
     @classmethod
     def find_by_name(cls, db, name):
         """Find a PadstackDef by name.
@@ -93,6 +90,11 @@ class PadstackDef(ObjBase):
         )
 
     @property
+    def definition_type(self):
+        """:class:`DefinitionObjType`: type."""
+        return DefinitionObjType.PADSTACK_DEF
+
+    @property
     def name(self):
         """:obj:`str`: Name of the PadstackDef.
 
@@ -109,3 +111,7 @@ class PadstackDef(ObjBase):
     @data.setter
     def data(self, data):
         self.__stub.SetData(_PadstackDefQueryBuilder.padstack_def_set_data_message(self, data))
+
+    def delete(self):
+        """Delete a PadstackDef."""
+        self.__stub.Delete(self.msg)

--- a/src/ansys/edb/edb_defs.py
+++ b/src/ansys/edb/edb_defs.py
@@ -28,7 +28,22 @@ class LayoutObjType(enum.Enum):
 
 
 class DefinitionObjType(enum.Enum):
-    """Definition Object Type."""
+    """
+    Definition Object Type.
+
+    - PADSTACK_DEF
+       Padstack definition.
+    - COMPONENT_DEF
+       Component definition.
+    - BONDWIRE_DEF
+       Bondwire definition.
+    - MATERIAL_DEF
+       Material definition.
+    - DATASET_DEF
+       Dataset definition.
+    - PACKAGE_DEF
+       Package definition.
+    """
 
     INVALID_DEFINITION_TYPE = definition_obj_pb2.INVALID_DEFINITION_TYPE
     PADSTACK_DEF = definition_obj_pb2.PADSTACK_DEF


### PR DESCRIPTION
`DefinitionBase` only contains `.name()` and `.definition_type()` methods. all subclasses already have `.names()` individually defined

note:
- grouped class methods and properties at the top of class definitions