### PR TITLE
D229: Python version packaging fix

### DIFF
--- a/protos/setup.py
+++ b/protos/setup.py
@@ -91,7 +91,7 @@ setup(
     description=desc,
     long_description=long_description,
     long_description_content_type="text/markdown",
-    python_requires=">=3.5.*",
+    python_requires=">=3.5",
     install_requires=install_requires,
     cmdclass={"develop": CustomDevelopCommand},
 )


### PR DESCRIPTION
closes #229 

As a result of the setuptools version being bumped up from 65.6.3 to 67.2.0, the packaging process of the ansys.api.edb.v1 package failed when tox is run during CI tests with the following error message:

'python_requires' must be a string containing valid version specifiers; Invalid specifier: '>=3.5.*'

In particular, the "Tests and coverage" and "Documentation" CI actions were failing due to their use of tox. Changing the format of the version specifier to be '>=3.5' resolved the issue by correcting the syntax and still enforcing the desired python version requirements.