### PR TITLE
D268: Add missing migration from pyansys to ansys

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -159,7 +159,7 @@ jobs:
           job: ${{ toJson(job) }}
           steps: ${{ toJson(steps) }}
           overwrite: "{
-            title: `New release has been published at https://github.com/pyansys/pyedb/releases`,
+            title: `New release has been published at https://github.com/ansys/pyedb/releases`,
             }"
 
       - name: Notify Failure
@@ -181,7 +181,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [doc-build, build]
     steps:
-      - uses: pyansys/actions/doc-deploy-dev@v4
+      - uses: ansys/actions/doc-deploy-dev@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     steps:
-      - uses: pyansys/actions/doc-deploy-stable@v4
+      - uses: ansys/actions/doc-deploy-stable@v4
         with:
           cname: ${{ env.DOCUMENTATION_CNAME }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ Pyedb
 
 Ansys Electronics Database Python Client
 
-.. image:: https://github.com/pyansys/pyedb/actions/workflows/ci_cd.yml/badge.svg?branch=develop
-   :target: https://github.com/pyansys/pyedb/actions/workflows/ci_cd.yml?query=branch%3Adevelop
+.. image:: https://github.com/ansys/pyedb/actions/workflows/ci_cd.yml/badge.svg?branch=develop
+   :target: https://github.com/ansys/pyedb/actions/workflows/ci_cd.yml?query=branch%3Adevelop
 
 How to install
 --------------
@@ -42,7 +42,7 @@ need to follow these steps:
 
     .. code:: bash
 
-        git clone https://github.com/pyansys/pyedb
+        git clone https://github.com/ansys/pyedb
         cd pyedb
 
 2. Create a fresh-clean Python environment and activate it:

--- a/doc/source/api/release_notes.rst
+++ b/doc/source/api/release_notes.rst
@@ -6,4 +6,4 @@ v1.0
 
 Known Issues:
 	* If a new database is opened after another one is closed, the server may fail to properly fetch objects that are created after the new database is opened.
-		* See `issue #154 <https://github.com/pyansys/pyedb/issues/154>`_
+		* See `issue #154 <https://github.com/ansys/pyedb/issues/154>`_

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -20,7 +20,7 @@ html_theme = "ansys_sphinx_theme"
 html_short_title = html_title = "PyEDB"
 
 html_context = {
-    "github_user": "pyansys",
+    "github_user": "ansys",
     "github_repo": "pyedb",
     "github_version": "develop",
     "doc_path": "doc/source",
@@ -32,7 +32,7 @@ html_theme_options = {
         "version_match": get_version_match(__version__),
     },
     "check_switcher": False,
-    "github_url": "https://github.com/pyansys/pyedb",
+    "github_url": "https://github.com/ansys/pyedb",
     "show_prev_next": False,
     "show_breadcrumbs": True,
     "collapse_navigation": True,

--- a/protos/setup.py
+++ b/protos/setup.py
@@ -85,7 +85,7 @@ setup(
     packages=["ansys.api.edb.v1"],
     version="0.0.0",
     license="MIT",
-    url="https://github.com/pyansys/",
+    url="https://github.com/ansys/",
     author="Ansys Inc.",
     author_email="support@ansys.com",
     description=desc,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 name = "ansys.edb"
 
 [project.urls]
-Source = "https://github.com/pyansys/pyedb"
+Source = "https://github.com/ansys/pyedb"
 
 [tool.black]
 line-length = 100


### PR DESCRIPTION
fixes #268 

This removes some remaining references to old pyansys org and point them to new ansys org.