### PR TITLE
D267: Add HFSS_3D_LAYOUT product type

### DIFF
--- a/src/ansys/edb/database.py
+++ b/src/ansys/edb/database.py
@@ -36,13 +36,14 @@ from ansys.edb.session import DatabaseServiceStub, StubAccessor, StubType
 class ProductIdType(Enum):
     """Enum representing the ids of Ansys products that support EDB usage.
 
-    - DESIGNER
+    - HFSS_3D_LAYOUT
+    - DESIGNER (deprecated. use HFSS_3D_LAYOUT instead)
     - SIWAVE
     - GENERIC_TRANSLATOR
     - USER_DEFINED
     """
 
-    DESIGNER = edb_defs_pb2.DESIGNER
+    HFSS_3D_LAYOUT = DESIGNER = edb_defs_pb2.DESIGNER
     SIWAVE = edb_defs_pb2.SI_WAVE
     GENERIC_TRANSLATOR = edb_defs_pb2.GENERIC_TRANSLATOR
     USER_DEFINED = edb_defs_pb2.USER_DEFINED


### PR DESCRIPTION
fixes #267 

HFSS 3D Layout type is currently mapped as "DESIGNER" but such product doesn't exist on UI. Adding a new type `HFSS_3D_LAYOUT` type to be consistent.