### PR TITLE
FIX: update test package version to be dynamic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-edb-core"
-version = "0.1"
+version = "0.1.0"
 description = "A python wrapper for Ansys Edb service"
 readme = "README.rst"
 requires-python = ">=3.8"

--- a/tests/mock/test_metadata.py
+++ b/tests/mock/test_metadata.py
@@ -2,4 +2,13 @@ from ansys.edb.core import __version__
 
 
 def test_pkg_version():
-    assert __version__ == "0.1"
+    try:
+        import importlib.metadata as importlib_metadata
+    except ModuleNotFoundError:  # pragma: no cover
+        import importlib_metadata
+
+    # Read from the pyproject.toml
+    # major, minor, patch
+    read_version = importlib_metadata.version("ansys-edb-core")
+
+    assert __version__ == read_version


### PR DESCRIPTION
Updating test on package version to make it dynamic (previously it was static). This will be less error-prone :)

@drewm102 This test has already been applied in branch release/0.1 and is cherry-picked from it. It was necessary since we use that branch to create the new tag v0.1.0