### PR TITLE
CI: add wheelhouse step

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -38,6 +38,23 @@ jobs:
           with:
             token: ${{ secrets.GITHUB_TOKEN }}
 
+  smoke-tests:
+    name: Build and Smoke tests
+    runs-on: ${{ matrix.os }}
+    needs: [style]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        python-version: ['3.8', '3.9', '3.10']
+    steps:
+      - name: Build wheelhouse and perform smoke test
+        uses: ansys/actions/build-wheelhouse@v5
+        with:
+          library-name: ${{ env.PACKAGE_NAME }}
+          operating-system: ${{ matrix.os }}
+          python-version: ${{ matrix.python-version }}
+
   tests:
     name: Tests and coverage
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run a PR title validation
-        run: grep -E "^(DOC:|REFACT:|FIX:|MAINT:|TEST:|FEATURE:)" <<< "${{ github.event.pull_request.title }}"
+        run: grep -E "^(CI:|DOC:|REFACT:|FIX:|MAINT:|TEST:|FEATURE:)" <<< "${{ github.event.pull_request.title }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-edb-core"
-version = "0.1.0"
+version = "0.1.1"
 description = "A python wrapper for Ansys Edb service"
 readme = "README.rst"
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-edb-core"
-version = "0.1.1"
+version = "0.1.dev0"
 description = "A python wrapper for Ansys Edb service"
 readme = "README.rst"
 requires-python = ">=3.8"


### PR DESCRIPTION
Release 0.1.1 got canceled because the wheelhouses were not built during CI.
This PR adds a job that will build the wheelhouses on top of performing smoke testing.

**Note**: Extra changes include :
- the project version to be 0.1.dev0 (should be the case in the main branch)
- the PR's template validation is extended to accept "CI:"