### PR TITLE
CI: Use self-hosted runner

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -79,6 +79,25 @@ jobs:
         # Only the tox environment specified in the tox.ini gh-actions is run
         run: tox -e test -- --ignore=tests/e2e
 
+  tests-e2e:
+    name: End to end tests and coverage
+    runs-on: [ self-hosted, Windows, pyedb-core ]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade .[tests]
+          python -m pip install --upgrade tox-gh-actions
+
+      - name: Test with tox
+        # Only the tox environment specified in the tox.ini gh-actions is run
+        run: tox -e test -- tests/e2e
+
   doc-build:
     name: "Doc build"
     runs-on: ubuntu-latest

--- a/tox.ini
+++ b/tox.ini
@@ -30,9 +30,10 @@ install_command =
 description = Checks for project unit tests
 setenv =
     PYTEST_EXTRA_ARGS = --junitxml=junit/test-results.xml
+    ANSYSEM_EDB_EXE_DIR={env:ANSYSEM_ROOT251}
 commands =
     python -m pip install .[tests]
-    pytest {posargs} {env:PYTEST_EXTRA_ARGS:}
+    pytest {posargs} {env:PYTEST_EXTRA_ARGS:ANSYSEM_EDB_EXE_DIR}
 
 [testenv:coverage]
 description = Checks for project unit tests and coverage


### PR DESCRIPTION
This is a sandbox to test using the new self-hosted runner. A good target would be to update the CICD to be able to run the current end to end tests.

@drewm102 What do we need to update in the CICD to make the example run correctly (assuming they don't fail) ? I expect that we have to add, at least, one secret for the server side. Something else ?