### PR TITLE
FEATURE: Auto select server port

### DIFF
--- a/tests/e2e/unit_tests/test_session.py
+++ b/tests/e2e/unit_tests/test_session.py
@@ -5,16 +5,26 @@ import socket
 import settings
 
 from ansys.edb.core.database import Database
-from ansys.edb.core.session import _Session, launch_session
+import ansys.edb.core.session as session
 
 
-def test_default_port_in_use(tmp_path: Path):
+def test_launch_session_when_default_port_in_use(new_database_path: Path):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(("127.0.0.1", 50051))
-        sess: _Session = launch_session(settings.server_exe_dir())
+        sess: session._Session = session.launch_session(settings.server_exe_dir())
         try:
-            edb_path = tmp_path / "p1.aedb"
-            with closing(Database.create(edb_path.as_posix())) as db:
+            assert isinstance(sess.port_num, int) and sess.port_num != 50051
+            with closing(Database.create(new_database_path)) as db:
                 assert not db.is_null
         finally:
             sess.disconnect()
+
+
+def test_session_when_default_port_in_use(new_database_path: Path):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 50051))
+        with session.session(settings.server_exe_dir()):
+            sess: session._Session = session.MOD.current_session
+            assert isinstance(sess.port_num, int) and sess.port_num != 50051
+            with closing(Database.create(new_database_path)) as db:
+                assert not db.is_null

--- a/tests/e2e/unit_tests/test_session.py
+++ b/tests/e2e/unit_tests/test_session.py
@@ -1,0 +1,20 @@
+from contextlib import closing
+from pathlib import Path
+import socket
+
+import settings
+
+from ansys.edb.core.database import Database
+from ansys.edb.core.session import _Session, launch_session
+
+
+def test_default_port_in_use(tmp_path: Path):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 50051))
+        sess: _Session = launch_session(settings.server_exe_dir())
+        try:
+            edb_path = tmp_path / "p1.aedb"
+            with closing(Database.create(edb_path.as_posix())) as db:
+                assert not db.is_null
+        finally:
+            sess.disconnect()


### PR DESCRIPTION
Add a function `_find_available_port` to find a port in the range [50051, 60000] that is available to open a listening socket on.  Use this function to automatically select a port when either `launch_session` or `session` are used to launch a gRPC server session
and `port_num` is `None` (the default).

Closes #478 