### PR TITLE
FIX: Net.extended_net returns first ExtendedNet object

### DIFF
--- a/src/ansys/edb/core/net/net.py
+++ b/src/ansys/edb/core/net/net.py
@@ -117,5 +117,8 @@ class Net(layout_obj.LayoutObj):
 
         This property is read-only.
         """
-        en = self._layout_objs(LayoutObjType.NET_CLASS)[0]
+        en = self._layout_objs(LayoutObjType.EXTENDED_NET)
+        if not en:
+            return None
+        en = en[0]
         return None if en.is_null else en


### PR DESCRIPTION
closes #476 