### PR TITLE
DOC: Fix up definition module docs Part 1

### DIFF
--- a/doc/source/api/glossary.rst
+++ b/doc/source/api/glossary.rst
@@ -97,3 +97,11 @@ Glossary
 		| 	Airbox negative vertical extent size. First parameter is the value and second parameter indicates if the value is a multiple.
 		| **airbox_truncate_at_ground**: :obj:`bool`
 		| 	Whether airbox will be truncated at the ground layers.
+
+	Anisotropic Material Property Component IDs
+
+		Anisotropic material properties use component ID values to specify tensor diagonal entries. Component ID values map to tensor diagonal entries as follows:
+
+		- ``0`` -> ``T[1,1]``
+		- ``1`` -> ``T[2,2]``
+		- ``2`` -> ``T[3,3]``

--- a/src/ansys/edb/core/definition/dataset_def.py
+++ b/src/ansys/edb/core/definition/dataset_def.py
@@ -1,4 +1,12 @@
 """Dataset definition."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:
+    from ansys.edb.core.database import Database
+    from ansys.edb.core.geometry.point_data import PointData
+
 from ansys.api.edb.v1.dataset_def_pb2_grpc import DatasetDefServiceStub
 
 from ansys.edb.core.edb_defs import DefinitionObjType
@@ -14,77 +22,79 @@ from ansys.edb.core.session import StubAccessor, StubType
 
 
 class DatasetDef(ObjBase):
-    """Represents a dataset definition."""
+    """A collection of data points which can be used to define piecewise functions."""
 
     __stub: DatasetDefServiceStub = StubAccessor(StubType.dataset_def)
 
     @classmethod
-    def create(cls, database, name):
+    def create(cls, database: Database, name: str) -> DatasetDef:
         """Create a dataset definition object.
 
         Parameters
         ----------
-        database : :class:`.Database`
+        database : .Database
             Database to create the dataset definition in.
-        name : :obj:`str`
-            Name of the dataset to create.
-
+        name : str
+            Name of the dataset definition to create.
 
         Returns
         -------
-        DatasetDef
+        .DatasetDef
         """
         return DatasetDef(cls.__stub.Create(string_property_message(database, name)))
 
     @classmethod
-    def find_by_name(cls, database, name):
+    def find_by_name(cls, database: Database, name: str) -> DatasetDef:
         """Find a dataset definition by name in a given database.
 
         Parameters
         ----------
-        database : :class:`.Database`
-            Database to search for the dataset definition.
-        name : :obj:`str`
+        database : .Database
+            Database to search for the dataset definition in.
+        name : str
             Name of the dataset definition.
 
         Returns
         -------
-        DatasetDef
+        .DatasetDef
             Dataset definition object found.
-            If a dataset isn't found, the dataset's ``is_null`` attribute is set to ``True``.
+            If a dataset definition isn't found, the returned dataset definition is :meth:`null <.is_null>`.
         """
         return DatasetDef(cls.__stub.FindByName(edb_obj_name_message(database, name)))
 
     @property
-    def definition_type(self):
-        """:class:`.DefinitionObjType`: Definition type."""
+    def definition_type(self) -> DefinitionObjType:
+        """:class:`.DefinitionObjType`: Definition type.
+
+        This property is read-only.
+        """
         return DefinitionObjType.DATASET_DEF
 
     @property
-    def name(self):
+    def name(self) -> str:
         """:obj:`str`: Name of the dataset definition."""
         return self.__stub.GetName(edb_obj_message(self)).value
 
     @name.setter
-    def name(self, name):
+    def name(self, name: str):
         self.__stub.SetName(string_property_message(self, name))
 
     @to_point_data_list
-    def get_data(self):
-        """Get a list of data points in the dataset definition.
+    def get_data(self) -> List[PointData]:
+        """Get the collection of data points the dataset definition represents.
 
         Returns
         -------
-        list[:class:`.PointData`]
+        list of .PointData
         """
         msg = self.__stub.GetData(edb_obj_message(self))
         return msg.points
 
-    def set_data(self, points):
-        """Set a list of data points in the dataset definition.
+    def set_data(self, points: List[PointData]):
+        """Set the collection of data points the dataset definition represents.
 
         Parameters
         ----------
-        points : list[:class:`.PointData`]
+        points : list of .PointData
         """
         self.__stub.SetData(points_property_message(self, points))

--- a/src/ansys/edb/core/definition/debye_model.py
+++ b/src/ansys/edb/core/definition/debye_model.py
@@ -1,4 +1,6 @@
 """Dielectric material definition."""
+from typing import Tuple
+
 from ansys.api.edb.v1 import debye_model_pb2_grpc
 import ansys.api.edb.v1.debye_model_pb2 as pb
 from google.protobuf import empty_pb2
@@ -9,44 +11,48 @@ from ansys.edb.core.inner import messages
 
 
 class DebyeModel(DielectricMaterialModel):
-    """Representa a Debye dielectric material model object."""
+    """Represents a Debye dielectric material model."""
 
     __stub: debye_model_pb2_grpc.DebyeModelServiceStub = session.StubAccessor(
         session.StubType.debye_model
     )
 
     @classmethod
-    def create(cls):
+    def create(cls) -> "DebyeModel":
         """Create a Debye dielectric material model.
 
         Returns
         -------
-        DebyeModelService
+        .DebyeModel
         """
         return DebyeModel(cls.__stub.Create(empty_pb2.Empty()))
 
     @property
-    def frequency_range(self):
-        """:obj:`tuple` of :obj:`float`, :obj:`float`: Frequency range (low, high)."""
+    def frequency_range(self) -> Tuple[float, float]:
+        """:obj:`tuple` of (:obj:`float`, :obj:`float`): Frequency range (low, high)."""
         range_msg = self.__stub.GetFrequencyRange(messages.edb_obj_message(self))
         return range_msg.low.value, range_msg.high.value
 
     @frequency_range.setter
-    def frequency_range(self, freq):
+    def frequency_range(self, freq: Tuple[float, float]):
         low = freq[0]
         high = freq[1]
         self.__stub.SetFrequencyRange(DebyeModel._set_frequency_range_message(self, low, high))
 
     @property
-    def relative_permitivity_at_high_low_frequency(self):
-        """:obj:`tuple` of :obj:`float`, :obj:`float`: Relative permitivity frequency range (low, high)."""
+    def relative_permittivity_at_high_low_frequency(self) -> Tuple[float, float]:
+        """:obj:`tuple` of (:obj:`float`, :obj:`float`): \
+        Relative permittivity value at the frequency range minimum and maximum.
+
+        Tuple is of the form ``(rel_perm_at_min_freq, rel_perm_at_max_freq)``.
+        """
         range_msg = self.__stub.GetRelativePermitivityAtHighLowFrequency(
             messages.edb_obj_message(self)
         )
         return range_msg.low.value, range_msg.high.value
 
-    @relative_permitivity_at_high_low_frequency.setter
-    def relative_permitivity_at_high_low_frequency(self, freq):
+    @relative_permittivity_at_high_low_frequency.setter
+    def relative_permittivity_at_high_low_frequency(self, freq: Tuple[float, float]):
         low = freq[0]
         high = freq[1]
         self.__stub.SetRelativePermitivityAtHighLowFrequency(
@@ -54,13 +60,17 @@ class DebyeModel(DielectricMaterialModel):
         )
 
     @property
-    def loss_tangent_at_high_low_frequency(self):
-        """:obj:`tuple` of :obj:`float`, :obj:`float`: Loss tangent frequency range (low, high)."""
+    def loss_tangent_at_high_low_frequency(self) -> Tuple[float, float]:
+        """:obj:`tuple` of (:obj:`float`, :obj:`float`): \
+        Dielectric loss tangent value at the frequency range minimum and maximum.
+
+        Tuple is of the form ``(diel_loss_tan_at_min_freq, diel_loss_tan_at_max_freq)``.
+        """
         range_msg = self.__stub.GetLossTangentAtHighLowFrequency(messages.edb_obj_message(self))
         return range_msg.low.value, range_msg.high.value
 
     @loss_tangent_at_high_low_frequency.setter
-    def loss_tangent_at_high_low_frequency(self, freq):
+    def loss_tangent_at_high_low_frequency(self, freq: Tuple[float, float]):
         low = freq[0]
         high = freq[1]
         self.__stub.SetLossTangentAtHighLowFrequency(
@@ -68,43 +78,43 @@ class DebyeModel(DielectricMaterialModel):
         )
 
     @property
-    def is_relative_permitivity_enabled_at_optical_frequency(self):
-        """:obj:`bool`: Flag indicating if the relative permitivity at optical frequency is enabled."""
+    def is_relative_permitivity_enabled_at_optical_frequency(self) -> bool:
+        """:obj:`bool`: Flag indicating if the relative permittivity at optical frequency is enabled."""
         return self.__stub.IsRelativePermitivityEnabledAtOpticalFrequency(self.msg).value
 
     @is_relative_permitivity_enabled_at_optical_frequency.setter
-    def is_relative_permitivity_enabled_at_optical_frequency(self, enabled):
+    def is_relative_permitivity_enabled_at_optical_frequency(self, enabled: bool):
         self.__stub.SetRelativePermitivityEnabledAtOpticalFrequency(
             messages.bool_property_message(self, enabled)
         )
 
     @property
-    def use_dc_conductivity(self):
+    def use_dc_conductivity(self) -> bool:
         """:obj:`bool`: Flag indicating if the DC conductivity nominal value is used."""
         return self.__stub.UseDCConductivity(self.msg).value
 
     @use_dc_conductivity.setter
-    def use_dc_conductivity(self, enabled):
+    def use_dc_conductivity(self, enabled: bool):
         self.__stub.SetUseDCConductivity(messages.bool_property_message(self, enabled))
 
     @property
-    def relative_permitivity_at_optical_frequency(self):
-        """:obj:`float`: Relative permitivity at the optical frequency."""
+    def relative_permittivity_at_optical_frequency(self) -> float:
+        """:obj:`float`: Relative permittivity value at the optical frequency."""
         return self.__stub.GetRelativePermitivityAtOpticalFrequency(self.msg).value
 
-    @relative_permitivity_at_optical_frequency.setter
-    def relative_permitivity_at_optical_frequency(self, frequency):
+    @relative_permittivity_at_optical_frequency.setter
+    def relative_permittivity_at_optical_frequency(self, frequency: float):
         self.__stub.SetRelativePermitivityAtOpticalFrequency(
             messages.double_property_message(self, frequency)
         )
 
     @property
-    def dc_conductivity(self):
+    def dc_conductivity(self) -> float:
         """:obj:`float`: DC conductivity nominal value."""
         return self.__stub.GetDCConductivity(self.msg).value
 
     @dc_conductivity.setter
-    def dc_conductivity(self, conductivity):
+    def dc_conductivity(self, conductivity: float):
         self.__stub.SetDCConductivity(messages.double_property_message(self, conductivity))
 
     @staticmethod

--- a/src/ansys/edb/core/definition/debye_model.py
+++ b/src/ansys/edb/core/definition/debye_model.py
@@ -1,4 +1,6 @@
 """Dielectric material definition."""
+from __future__ import annotations
+
 from typing import Tuple
 
 from ansys.api.edb.v1 import debye_model_pb2_grpc
@@ -18,7 +20,7 @@ class DebyeModel(DielectricMaterialModel):
     )
 
     @classmethod
-    def create(cls) -> "DebyeModel":
+    def create(cls) -> DebyeModel:
         """Create a Debye dielectric material model.
 
         Returns

--- a/src/ansys/edb/core/definition/die_property.py
+++ b/src/ansys/edb/core/definition/die_property.py
@@ -1,4 +1,10 @@
 """Die property."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ansys.edb.core.typing import ValueLike
 
 from enum import Enum
 
@@ -12,14 +18,14 @@ from ansys.edb.core.utility.value import Value
 
 
 class DieOrientation(Enum):
-    """Provides an enum representing die orientations."""
+    """Enum representing die orientations."""
 
     CHIP_UP = die_property_pb2.DIE_ORIENTATION_CHIP_UP
     CHIP_DOWN = die_property_pb2.DIE_ORIENTATION_CHIP_DOWN
 
 
 class DieType(Enum):
-    """Provides an enum representing die types."""
+    """Enum representing die types."""
 
     NONE = die_property_pb2.DIE_TYPE_NONE
     FLIPCHIP = die_property_pb2.DIE_TYPE_FLIPCHIP
@@ -27,59 +33,54 @@ class DieType(Enum):
 
 
 class DieProperty(ObjBase):
-    """Represents a die property."""
+    """Represents the properties of a die."""
 
     __stub: DiePropertyServiceStub = StubAccessor(StubType.die_property)
 
     @classmethod
-    def create(cls):
+    def create(cls) -> DieProperty:
         """
         Create a die property.
 
         Returns
         -------
-        DieProperty
-            Die property created.
+        .DieProperty
         """
         return DieProperty(cls.__stub.Create(empty_pb2.Empty()))
 
-    def clone(self):
+    def clone(self) -> DieProperty:
         """
         Clone a die property.
 
         Returns
         -------
-        DieProperty
-            Die property cloned.
+        .DieProperty
         """
         return DieProperty(self.__stub.Clone(messages.edb_obj_message(self)))
 
     @property
-    def die_type(self):
-        """:obj:`DieType`: Die type."""
+    def die_type(self) -> DieType:
+        """:class:`.DieType`: Die type."""
         return DieType(self.__stub.GetDieType(self.msg).die_type)
 
     @die_type.setter
-    def die_type(self, value):
+    def die_type(self, value: DieType):
         self.__stub.SetDieType(messages.set_die_type_message(self, value))
 
     @property
-    def height(self):
-        """:class:`.Value`: Die height.
-
-        This property can be set with :term:`ValueLike`.
-        """
+    def height(self) -> Value:
+        """:class:`.Value`: Die height."""
         return Value(self.__stub.GetHeight(messages.edb_obj_message(self)))
 
     @height.setter
-    def height(self, height):
+    def height(self, height: ValueLike):
         self.__stub.SetHeight(messages.value_property_message(self, messages.value_message(height)))
 
     @property
-    def die_orientation(self):
-        """:obj:`DieOrientation`: Die orientation."""
+    def die_orientation(self) -> DieOrientation:
+        """:class:`.DieOrientation`: Die orientation."""
         return DieOrientation(self.__stub.GetOrientation(self.msg).die_orientation)
 
     @die_orientation.setter
-    def die_orientation(self, value):
+    def die_orientation(self, value: DieOrientation):
         self.__stub.SetOrientation(messages.set_die_orientation_message(self, value))

--- a/src/ansys/edb/core/definition/dielectric_material_model.py
+++ b/src/ansys/edb/core/definition/dielectric_material_model.py
@@ -8,7 +8,7 @@ from ansys.edb.core.inner import ObjBase
 
 
 class DielectricMaterialModelType(Enum):
-    """Provides an eum representing dielectric material model types."""
+    """Enum representing dielectric material model types."""
 
     DEBYE = 0
     MULTIPOLE_DEBYE = 1
@@ -23,6 +23,9 @@ class DielectricMaterialModel(ObjBase):
     )
 
     @property
-    def type(self):
-        """:class:`DielectricMaterialModelType`: Type of the dielectric material model."""
+    def type(self) -> DielectricMaterialModelType:
+        """:class:`.DielectricMaterialModelType`: Type of the dielectric material model.
+
+        This property is read-only.
+        """
         return DielectricMaterialModelType(self.__stub.GetType(self.msg).value)

--- a/src/ansys/edb/core/definition/djordjecvic_sarkar_model.py
+++ b/src/ansys/edb/core/definition/djordjecvic_sarkar_model.py
@@ -1,4 +1,6 @@
 """Dielectric material definition."""
+from __future__ import annotations
+
 from ansys.api.edb.v1 import djordjecvic_sarkar_model_pb2_grpc
 from google.protobuf import empty_pb2
 
@@ -15,7 +17,7 @@ class DjordjecvicSarkarModel(DielectricMaterialModel):
     )
 
     @classmethod
-    def create(cls) -> "DjordjecvicSarkarModel":
+    def create(cls) -> DjordjecvicSarkarModel:
         """Create a Djordjecvic Sarkar dielectric material model.
 
         Returns

--- a/src/ansys/edb/core/definition/djordjecvic_sarkar_model.py
+++ b/src/ansys/edb/core/definition/djordjecvic_sarkar_model.py
@@ -8,74 +8,74 @@ from ansys.edb.core.inner import messages
 
 
 class DjordjecvicSarkarModel(DielectricMaterialModel):
-    """Represents a Djordjecvic-Sarkar dielectric material model object."""
+    """Represents a Djordjecvic-Sarkar dielectric material model."""
 
     __stub: djordjecvic_sarkar_model_pb2_grpc.DjordjecvicSarkarModelServiceStub = (
         session.StubAccessor(session.StubType.djordecvic_sarkar_model)
     )
 
     @classmethod
-    def create(cls):
+    def create(cls) -> "DjordjecvicSarkarModel":
         """Create a Djordjecvic Sarkar dielectric material model.
 
         Returns
         -------
-        DjordjecvicSarkarModel
+        .DjordjecvicSarkarModel
         """
         return DjordjecvicSarkarModel(cls.__stub.Create(empty_pb2.Empty()))
 
     @property
-    def use_dc_relative_conductivity(self):
-        """:obj:`bool`: Flag indicating whether the DC relative permitivity nominal value is used."""
+    def use_dc_relative_conductivity(self) -> bool:
+        """:obj:`bool`: Flag indicating whether the DC relative permittivity nominal value is used."""
         return self.__stub.UseDCRelativePermitivity(self.msg).value
 
     @use_dc_relative_conductivity.setter
-    def use_dc_relative_conductivity(self, enabled):
+    def use_dc_relative_conductivity(self, enabled: bool):
         self.__stub.SetUseDCRelativePermitivity(messages.bool_property_message(self, enabled))
 
     @property
-    def frequency(self):
-        """:obj:`float`: Frequency."""
+    def frequency(self) -> float:
+        """:obj:`float`: Frequency value."""
         return self.__stub.GetFrequency(self.msg).value
 
     @frequency.setter
-    def frequency(self, frequency):
+    def frequency(self, frequency: float):
         self.__stub.SetFrequency(messages.double_property_message(self, frequency))
 
     @property
-    def relative_permitivity_at_frequency(self):
-        """:obj:`float`: Relative permitivity frequency."""
+    def relative_permittivity_at_frequency(self) -> float:
+        """:obj:`float`: Relative permittivity value at the specified :meth:`frequency <.frequency>`."""
         return self.__stub.GetRelativePermitivityAtFrequency(self.msg).value
 
-    @relative_permitivity_at_frequency.setter
-    def relative_permitivity_at_frequency(self, frequency):
+    @relative_permittivity_at_frequency.setter
+    def relative_permittivity_at_frequency(self, frequency: float):
         self.__stub.SetRelativePermitivityAtFrequency(
             messages.double_property_message(self, frequency)
         )
 
     @property
-    def loss_tangent_at_frequency(self):
-        """:obj:`float`: Loss tangent at frequency."""
+    def loss_tangent_at_frequency(self) -> float:
+        """:obj:`float`: Loss tangent value at the specified :meth:`frequency <.frequency>`."""
         return self.__stub.GetLossTangentAtFrequency(self.msg).value
 
     @loss_tangent_at_frequency.setter
-    def loss_tangent_at_frequency(self, frequency):
+    def loss_tangent_at_frequency(self, frequency: float):
         self.__stub.SetLossTangentAtFrequency(messages.double_property_message(self, frequency))
 
     @property
-    def dc_relative_permitivity(self):
-        """:obj:`float`: DC relative permitivity."""
+    def dc_relative_permittivity(self) -> float:
+        """:obj:`float`: DC relative permittivity value."""
         return self.__stub.GetDCRelativePermitivity(self.msg).value
 
-    @dc_relative_permitivity.setter
-    def dc_relative_permitivity(self, permitivity):
-        self.__stub.SetDCRelativePermitivity(messages.double_property_message(self, permitivity))
+    @dc_relative_permittivity.setter
+    def dc_relative_permittivity(self, permittivity: float):
+        self.__stub.SetDCRelativePermitivity(messages.double_property_message(self, permittivity))
 
     @property
-    def dc_conductivity(self):
-        """:obj:`float`: DC conductivity."""
+    def dc_conductivity(self) -> float:
+        """:obj:`float`: DC conductivity value."""
         return self.__stub.GetDCConductivity(self.msg).value
 
     @dc_conductivity.setter
-    def dc_conductivity(self, conductivity):
+    def dc_conductivity(self, conductivity: float):
         self.__stub.SetDCConductivity(messages.double_property_message(self, conductivity))

--- a/src/ansys/edb/core/definition/ic_component_property.py
+++ b/src/ansys/edb/core/definition/ic_component_property.py
@@ -1,38 +1,39 @@
 """IC component property."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.ansys.edb.core.definition.die_property import DieProperty
+    from src.ansys.edb.core.definition.solder_ball_property import SolderBallProperty
 
 from ansys.api.edb.v1.ic_component_property_pb2_grpc import ICComponentPropertyServiceStub
 import google.protobuf.empty_pb2 as empty_pb2
 
-from ansys.edb.core.definition import (
-    component_property,
-    die_property,
-    port_property,
-    solder_ball_property,
-)
+from ansys.edb.core.definition import component_property, die_property, solder_ball_property
+from ansys.edb.core.definition.port_property import PortProperty
 from ansys.edb.core.inner import messages
 from ansys.edb.core.session import StubAccessor, StubType
 
 
 class ICComponentProperty(component_property.ComponentProperty):
-    """Represents an IC component property."""
+    """Represents the properties of an IC component."""
 
     __stub: ICComponentPropertyServiceStub = StubAccessor(StubType.ic_component_property)
 
     @classmethod
-    def create(cls):
-        """
-        Create an IC component property.
+    def create(cls) -> ICComponentProperty:
+        """Create an IC component property.
 
         Returns
         -------
-        ICComponentProperty
-            IC component property created.
+        .ICComponentProperty
         """
         return ICComponentProperty(cls.__stub.Create(empty_pb2.Empty()))
 
     @property
-    def solder_ball_property(self):
-        """:obj:`SolderBallProperty`: Solder ball property.
+    def solder_ball_property(self) -> SolderBallProperty:
+        """:class:`.SolderBallProperty`: Solder ball properties of the IC component.
 
         A copy is returned. Use the setter for any modifications to be reflected.
         """
@@ -41,33 +42,31 @@ class ICComponentProperty(component_property.ComponentProperty):
         )
 
     @solder_ball_property.setter
-    def solder_ball_property(self, value):
+    def solder_ball_property(self, value: SolderBallProperty):
         self.__stub.SetSolderBallProperty(
             messages.pointer_property_message(target=self, value=value)
         )
 
     @property
-    def die_property(self):
-        """:obj:`DieProperty`: Die property.
+    def die_property(self) -> DieProperty:
+        """:class:`.DieProperty`: Die properties of the IC component.
 
         A copy is returned. Use the setter for any modifications to be reflected.
         """
         return die_property.DieProperty(self.__stub.GetDieProperty(messages.edb_obj_message(self)))
 
     @die_property.setter
-    def die_property(self, value):
+    def die_property(self, value: DieProperty):
         self.__stub.SetDieProperty(messages.pointer_property_message(target=self, value=value))
 
     @property
-    def port_property(self):
-        """:obj:`PortProperty`: Port property.
+    def port_property(self) -> PortProperty:
+        """:class:`.PortProperty`: Port properties of the IC component.
 
         A copy is returned. Use the setter for any modifications to be reflected.
         """
-        return port_property.PortProperty(
-            self.__stub.GetPortProperty(messages.edb_obj_message(self))
-        )
+        return PortProperty(self.__stub.GetPortProperty(messages.edb_obj_message(self)))
 
     @port_property.setter
-    def port_property(self, value):
+    def port_property(self, value: PortProperty):
         self.__stub.SetPortProperty(messages.pointer_property_message(target=self, value=value))

--- a/src/ansys/edb/core/definition/io_component_property.py
+++ b/src/ansys/edb/core/definition/io_component_property.py
@@ -1,33 +1,39 @@
 """IO component property."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ansys.edb.core.definition.port_property import PortProperty
+    from src.ansys.edb.core.definition.solder_ball_property import SolderBallProperty
 
 from ansys.api.edb.v1.io_component_property_pb2_grpc import IOComponentPropertyServiceStub
 import google.protobuf.empty_pb2 as empty_pb2
 
-from ansys.edb.core.definition import component_property, port_property, solder_ball_property
+from ansys.edb.core.definition import component_property, solder_ball_property
 from ansys.edb.core.inner import messages
 from ansys.edb.core.session import StubAccessor, StubType
 
 
 class IOComponentProperty(component_property.ComponentProperty):
-    """Represents an I0 component property."""
+    """Represents the properties of an I0 component."""
 
     __stub: IOComponentPropertyServiceStub = StubAccessor(StubType.io_component_property)
 
     @classmethod
-    def create(cls):
+    def create(cls) -> IOComponentProperty:
         """
         Create an IO component property.
 
         Returns
         -------
-        IOComponentProperty
-            IO component property created.
+        .IOComponentProperty
         """
         return IOComponentProperty(cls.__stub.Create(empty_pb2.Empty()))
 
     @property
-    def solder_ball_property(self):
-        """:obj:`SolderBallProperty`: Solder ball property.
+    def solder_ball_property(self) -> SolderBallProperty:
+        """:class:`.SolderBallProperty`: Solder ball properties of the IO component.
 
         A copy is returned. Use the setter for any modifications to be reflected.
         """
@@ -36,21 +42,19 @@ class IOComponentProperty(component_property.ComponentProperty):
         )
 
     @solder_ball_property.setter
-    def solder_ball_property(self, value):
+    def solder_ball_property(self, value: SolderBallProperty):
         self.__stub.SetSolderBallProperty(
             messages.pointer_property_message(target=self, value=value)
         )
 
     @property
-    def port_property(self):
-        """:obj:`PortProperty`: Port property.
+    def port_property(self) -> PortProperty:
+        """:class:`.PortProperty`: Port properties of the IO component.
 
         A copy is returned. Use the setter for any modifications to be reflected.
         """
-        return port_property.PortProperty(
-            self.__stub.GetPortProperty(messages.edb_obj_message(self))
-        )
+        return PortProperty(self.__stub.GetPortProperty(messages.edb_obj_message(self)))
 
     @port_property.setter
-    def port_property(self, value):
+    def port_property(self, value: PortProperty):
         self.__stub.SetPortProperty(messages.pointer_property_message(target=self, value=value))


### PR DESCRIPTION
Fixes of documentation for the following modules:

- dataset_def.py
- debye_model.py
- die_property.py
- dielectric_material_model.py
- djordjecvic_sarkar_model.py
- ic_component_property.py
- io_component_property.py
- material_def.py