### PR TITLE
FIX: #555 solder_ball_property not available with ComponentType.OTHER

### DIFF
--- a/src/ansys/edb/core/hierarchy/component_group.py
+++ b/src/ansys/edb/core/hierarchy/component_group.py
@@ -77,12 +77,13 @@ class ComponentGroup(Group):
             or comp_type == edb_defs_pb2.ComponentType.CAPACITOR
         ):
             return RLCComponentProperty(comp_prop.msg)
-        if comp_type == edb_defs_pb2.ComponentType.IO:
-            return IOComponentProperty(comp_prop.msg)
         if comp_type == edb_defs_pb2.ComponentType.IC:
             return ICComponentProperty(comp_prop.msg)
-        if comp_type == edb_defs_pb2.ComponentType.OTHER:
-            return comp_prop
+        if (
+            comp_type == edb_defs_pb2.ComponentType.IO
+            or comp_type == edb_defs_pb2.ComponentType.OTHER
+        ):
+            return IOComponentProperty(comp_prop.msg)
         else:
             return None
 


### PR DESCRIPTION
component_type.other is included in IsIO() and should return IOComponentProperty, not the base class.

closes #555 