### PR TITLE
CHORE: bump main branch version to v0.3.0.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-edb-core"
-version = "0.2.0.dev5"
+version = "0.3.0.dev0"
 description = "A python wrapper for Ansys Edb service"
 readme = "README.rst"
 requires-python = ">=3.8"


### PR DESCRIPTION
Now that v0.2.0 is already out, shouldn't this be bumped?