### PR TITLE
FIX: fix typo in runner name

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -108,7 +108,7 @@ jobs:
     name: Release project
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [package]
-    runs-on: ubuntu-latest*
+    runs-on: ubuntu-latest
     # Specifying a GitHub environment is optional, but strongly encouraged
     environment: release
     permissions:


### PR DESCRIPTION
As title says. This is probably the reason why release can't be performed. Sry for that typo...