### PR TITLE
FIX: Read multiple frequency ranges from sweep definition

### DIFF
--- a/src/ansys/edb/core/simulation_setup/simulation_setup.py
+++ b/src/ansys/edb/core/simulation_setup/simulation_setup.py
@@ -373,6 +373,8 @@ def _msg_to_sweep_data(msg):
         FrequencyData(Distribution[params[0]], *params[1:4])
         for params in (line.split() for line in freq_str_ranges if line.strip())
     ]
+    if len(ff) == 1:
+        ff = ff[0]
     sweep_data = SweepData(msg.name, ff)
     sweep_data.enabled = msg.enabled
     sweep_data.type = FreqSweepType(msg.type)

--- a/tests/e2e/integration_tests/test_siwave_simulation_setup.py
+++ b/tests/e2e/integration_tests/test_siwave_simulation_setup.py
@@ -1,21 +1,37 @@
+import pytest
+
 from ansys.edb.core.layout.cell import Cell
 from ansys.edb.core.simulation_setup.simulation_setup import Distribution, FrequencyData, SweepData
 from ansys.edb.core.simulation_setup.siwave_simulation_setup import SIWaveSimulationSetup
 
 
-def test_create_siwave_simulation_setup(circuit_cell: Cell):
-    setup = SIWaveSimulationSetup.create(circuit_cell, "Setup1")
-    ff = [
+@pytest.mark.parametrize(
+    "frequency_data",
+    [
         FrequencyData(Distribution.LINC, "0GHz", "1GHz", "1001"),
-        FrequencyData(Distribution.DEC, "1kHz", "1GHz", "20"),
-    ]
-    sweep_data = SweepData("Sweep1", ff)
-    assert isinstance(sweep_data.frequency_data, list)
+        [
+            FrequencyData(Distribution.LINC, "0GHz", "1GHz", "1001"),
+            FrequencyData(Distribution.DEC, "1kHz", "1GHz", "20"),
+        ],
+    ],
+)
+def test_create_siwave_simulation_setup(
+    circuit_cell: Cell, frequency_data: FrequencyData | list[FrequencyData]
+):
+    setup = SIWaveSimulationSetup.create(circuit_cell, "Setup1")
+    sweep_data = SweepData("Sweep1", frequency_data)
+    assert isinstance(sweep_data.frequency_data, type(frequency_data))
     setup.sweep_data = [sweep_data]
-    assert isinstance(setup.sweep_data[0].frequency_data, list)
-    for i, fd in enumerate(ff):
-        fd_read = setup.sweep_data[0].frequency_data[i]
-        assert fd.distribution == fd_read.distribution
-        assert fd.start_f == fd_read.start_f
-        assert fd.end_f == fd_read.end_f
-        assert fd.step == fd_read.step
+    assert isinstance(setup.sweep_data[0].frequency_data, type(frequency_data))
+    if isinstance(frequency_data, list):
+        for i, fd in enumerate(frequency_data):
+            _assert_frequency_data_are_equal(fd, setup.sweep_data[0].frequency_data[i])
+    else:
+        _assert_frequency_data_are_equal(frequency_data, setup.sweep_data[0].frequency_data)
+
+
+def _assert_frequency_data_are_equal(fd1: FrequencyData, fd2: FrequencyData):
+    assert fd1.distribution == fd2.distribution
+    assert fd1.start_f == fd2.start_f
+    assert fd1.end_f == fd2.end_f
+    assert fd1.step == fd2.step


### PR DESCRIPTION
`simulation_setup._msg_to_sweep_data` was only considering the first entry in a multi-line frequency string and therefore missing any frequency range beyond the first one.  Update this to first split the frequency string into lines and then create a `FrequencyData` for each line.

Fixes #599 