### PR TITLE
FIX: Fix PrimitiveEdge primitive property getter

### DIFF
--- a/src/ansys/edb/core/terminal/edge_terminal.py
+++ b/src/ansys/edb/core/terminal/edge_terminal.py
@@ -52,7 +52,7 @@ class Edge(ObjBase):
     def _params(self):
         res = self.__stub.GetParameters(self.msg)
         if self.type == EdgeType.PRIMITIVE:
-            return res.primitive_params
+            return res.primitve_params
         elif self.type == EdgeType.PADSTACK:
             return res.pad_params
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -4,10 +4,16 @@ import settings
 from ansys.edb.core.database import Database
 from ansys.edb.core.definition.padstack_def import PadstackDef
 from ansys.edb.core.definition.padstack_def_data import PadGeometryType, PadstackDefData, PadType
+from ansys.edb.core.geometry.polygon_data import PolygonData
 from ansys.edb.core.layer.layer import LayerType
 from ansys.edb.core.layer.stackup_layer import StackupLayer
 from ansys.edb.core.layout.cell import Cell, CellType
+from ansys.edb.core.net.net import Net
+from ansys.edb.core.primitive.path import Path as Line
+from ansys.edb.core.primitive.path import PathCornerType, PathEndCapType
+from ansys.edb.core.primitive.rectangle import Rectangle, RectangleRepresentationType
 from ansys.edb.core.session import session
+from ansys.edb.core.terminal.edge_terminal import EdgeTerminal, PrimitiveEdge
 
 
 @pytest.fixture
@@ -76,3 +82,50 @@ def circuit_cell_with_padstack_def(circuit_cell_with_stackup: Cell):
     padstack_def = PadstackDef.create(db, "VIA050070100")
     padstack_def.data = padstack_def_data
     yield circuit_cell_with_stackup
+
+
+@pytest.fixture
+def circuit_cell_with_edge_terminals(circuit_cell_with_padstack_def: Cell) -> Cell:
+    _ = Rectangle.create(
+        circuit_cell_with_padstack_def.layout,
+        "L2",
+        Net.create(circuit_cell_with_padstack_def.layout, "GND"),
+        RectangleRepresentationType.CENTER_WIDTH_HEIGHT,
+        0.0,
+        0.0,
+        2e-3,
+        1e-3,
+        0.0,
+        0.0,
+    )
+
+    line = Line.create(
+        circuit_cell_with_padstack_def.layout,
+        "L1",
+        Net.create(circuit_cell_with_padstack_def.layout, "NET1"),
+        0.2e-3,
+        PathEndCapType.FLAT,
+        PathEndCapType.FLAT,
+        PathCornerType.ROUND,
+        PolygonData([[-0.9e-3, 0.0], [0.9e-3, 0.0]]),
+    )
+
+    edge1 = PrimitiveEdge.create(line, [-0.9e-3, 0.0])
+    edge_terminal1 = EdgeTerminal.create(
+        circuit_cell_with_padstack_def.layout,
+        "P1",
+        [edge1],
+        Net.find_by_name(circuit_cell_with_padstack_def.layout, "NET1"),
+    )
+    edge_terminal1.reference_layer = "L2"
+
+    edge2 = PrimitiveEdge.create(line, [0.9e-3, 0.0])
+    edge_terminal2 = EdgeTerminal.create(
+        circuit_cell_with_padstack_def.layout,
+        "P2",
+        [edge2],
+        Net.find_by_name(circuit_cell_with_padstack_def.layout, "NET1"),
+    )
+    edge_terminal2.reference_layer = "L2"
+
+    return circuit_cell_with_padstack_def

--- a/tests/e2e/unit_tests/test_edge_terminal.py
+++ b/tests/e2e/unit_tests/test_edge_terminal.py
@@ -1,0 +1,11 @@
+from ansys.edb.core.layout.cell import Cell
+from ansys.edb.core.primitive.primitive import PrimitiveType
+from ansys.edb.core.terminal.edge_terminal import EdgeTerminal
+from ansys.edb.core.terminal.terminal import Terminal
+
+
+def test_edge_primitive(circuit_cell_with_edge_terminals: Cell):
+    layout = circuit_cell_with_edge_terminals.layout
+    terminal: EdgeTerminal = Terminal.find(layout, "P1")
+    assert len(terminal.edges) == 1
+    assert terminal.edges[0].primitive.primitive_type == PrimitiveType.PATH

--- a/tests/e2e/unit_tests/test_edge_terminal.py
+++ b/tests/e2e/unit_tests/test_edge_terminal.py
@@ -4,7 +4,7 @@ from ansys.edb.core.terminal.edge_terminal import EdgeTerminal
 from ansys.edb.core.terminal.terminal import Terminal
 
 
-def test_edge_primitive(circuit_cell_with_edge_terminals: Cell):
+def test_primitive_edge_primitive(circuit_cell_with_edge_terminals: Cell):
     layout = circuit_cell_with_edge_terminals.layout
     terminal: EdgeTerminal = Terminal.find(layout, "P1")
     assert len(terminal.edges) == 1


### PR DESCRIPTION
Debugging revealed that the upstream API is returning a structure with a typo in an attribute name (i.e. `primitve_params` instead of `primitive_params`).  For now patch the client to look for this name.

Fixes #616 