### PR TITLE
FEATURE: Support density based via grouping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "flit_core.buildapi"
 [project]
 # Check https://flit.readthedocs.io/en/latest/pyproject_toml.html for all available sections
 name = "ansys-edb-core"
-version = "0.3.0.dev4"
+version = "0.3.0.dev5"
 description = "A python wrapper for Ansys Edb service"
 readme = "README.rst"
 requires-python = ">=3.8"


### PR DESCRIPTION
- Add support for via grouping based on density clustering.
- Replace the `simplification_method` argument with `clustering_method`.
- Rename `max_grouping_distance` argument to `tolerance`.

**Testing**
- Verified that the three clustering algorithms perform the same as when using them in the GUI.