### PR TITLE
FIX: Add client side methods for HFC in DS material model (#638)

### DIFF
--- a/src/ansys/edb/core/definition/djordjecvic_sarkar_model.py
+++ b/src/ansys/edb/core/definition/djordjecvic_sarkar_model.py
@@ -65,6 +65,15 @@ class DjordjecvicSarkarModel(DielectricMaterialModel):
         self.__stub.SetLossTangentAtFrequency(messages.double_property_message(self, frequency))
 
     @property
+    def high_frequency_corner(self) -> float:
+        """:obj:`float`: High frequency corner value for the model."""
+        return self.__stub.GetHighFrequencyCorner(self.msg).value
+
+    @high_frequency_corner.setter
+    def high_frequency_corner(self, corner: float):
+        self.__stub.SetHighFrequencyCorner(messages.double_property_message(self, corner))
+
+    @property
     def dc_relative_permittivity(self) -> float:
         """:obj:`float`: DC relative permittivity value."""
         return self.__stub.GetDCRelativePermitivity(self.msg).value


### PR DESCRIPTION
Please note that although this client side method has been added (server side exists already), It does not seem to be syncing with the .aedbt, even if it is visible in the  .aedb This is a seperate bug we will have to address in edt.