### PR TITLE
FEATURE: Add fill material support to backdrill methods

### DIFF
--- a/src/ansys/edb/core/primitive/padstack_instance.py
+++ b/src/ansys/edb/core/primitive/padstack_instance.py
@@ -333,6 +333,8 @@ class PadstackInstance(conn_obj.ConnObj):
         ----------
         from_bottom : bool
             Whether to get the back drill type from the bottom.
+        include_fill_material : bool, optional
+            Input flag to obtain fill material as well as other parameters. If false, the return tuple does not include fill material and is backward compatible with previous versions.
 
         Returns
         -------
@@ -345,7 +347,6 @@ class PadstackInstance(conn_obj.ConnObj):
             - **offset** : Layer offset (or depth if layer is empty).
             - **diameter** : Drilling diameter.
             - **fill_material** : Fill material name (empty string if no fill). Returned only when include_fill_material is true.
-            - **include_fill_material** : Input flag to obtain fill material as well as other parameters. If false, the return tuple does not include fill material and is backward compatible with previous versions.
         """
         params = self.__stub.GetBackDrillByLayer(
             PadstackInstance._get_back_drill_message(self, from_bottom)
@@ -420,7 +421,8 @@ class PadstackInstance(conn_obj.ConnObj):
         ----------
         from_bottom : bool
             Whether to get the back drill type from the bottom.
-
+        include_fill_material : bool, optional
+            Input flag to obtain fill material as well as other parameters. If false, the return tuple does not include fill material and is backward compatible with previous versions.
         Returns
         -------
         tuple of (.Value, .Value, str)
@@ -430,7 +432,6 @@ class PadstackInstance(conn_obj.ConnObj):
             - **diameter** : Drilling diameter.
             - **fill_material** : Fill material name (empty string if no fill),
               only included when ``include_fill_material`` is True.
-            - **include_fill_material** : Input flag to obtain fill material as well as other parameters. If false, the return tuple does not include fill material and is backward compatible with previous versions.
 
         """
         


### PR DESCRIPTION
Extend PadstackInstance backdrill methods to support an optional fill material parameter. The get_back_drill_by_layer and get_back_drill_by_depth methods now accept an include_fill_material flag and can return the fill material name. The set_back_drill_by_layer and set_back_drill_by_depth methods accept a fill_material argument. All changes are backward compatible and include updated type hints and documentation.

## Summary
Adds optional `fill_material` parameter to PadstackInstance back drill methods while maintaining 100% backwards compatibility.

## Changes Made

### API Changes
- ✅ Added optional `fill_material` parameter to `set_back_drill_by_depth()`
- ✅ Added optional `fill_material` parameter to `set_back_drill_by_layer()`
- ✅ Added `include_fill_material` flag to `get_back_drill_by_depth()` for opt-in behavior
- ✅ Added `include_fill_material` flag to `get_back_drill_by_layer()` for opt-in behavior
- ✅ Used method overloading for proper type hints

### Backwards Compatibility
- ✅ Existing code works without any changes
- ✅ Old unpacking patterns still work (2/3 values)
- ✅ New unpacking patterns supported (3/4 values)
- ✅ Default values ensure no breaking changes
