### PR TITLE
FIX: correct an undeclared variable reference

### DIFF
--- a/src/ansys/edb/core/layout_instance/layout_instance.py
+++ b/src/ansys/edb/core/layout_instance/layout_instance.py
@@ -105,7 +105,8 @@ class LayoutInstance(ObjBase):
         ]
         has_spatial_filter = spatial_filter is not None
         if has_spatial_filter:
-            for sf in utils.ensure_is_list(spatial_filter):
+            spatial_filter = utils.ensure_is_list(spatial_filter)
+            for sf in spatial_filter:
                 requests.append(spatial_filter_to_msg(sf))
 
         all_hits = []
@@ -140,8 +141,6 @@ class LayoutInstance(ObjBase):
         all_hits_iter = iter(all_hits)
         if not has_spatial_filter:
             return process_hits(None, all_hits_iter)
-        elif has_single_spatial_filter:
-            return process_hits(spatial_filter, all_hits_iter)
         elif len(spatial_filter) == 1:
             return process_hits(spatial_filter[0], all_hits_iter)
         else:

--- a/src/ansys/edb/core/layout_instance/layout_instance.py
+++ b/src/ansys/edb/core/layout_instance/layout_instance.py
@@ -103,13 +103,12 @@ class LayoutInstance(ObjBase):
                 **lyt_inst_net_filter_lyr_filter_params
             )
         ]
-        has_spatial_filter = spatial_filter is not None
         spatial_filter_was_list = isinstance(spatial_filter, list)
-        if has_spatial_filter:
-            spatial_filter = utils.ensure_is_list(spatial_filter)
-            for sf in spatial_filter:
+        if spatial_filter is not None:
+            for sf in utils.ensure_is_list(spatial_filter):
                 requests.append(spatial_filter_to_msg(sf))
 
+        # Run queries and gather hits
         all_hits = []
         if is_in_memory():
             queries_msg = layout_instance_pb2.LayoutObjInstancesQueriesMessage(
@@ -139,15 +138,14 @@ class LayoutInstance(ObjBase):
                 (full_hits, partial_hits) if isinstance(_spatial_filter, PolygonData) else full_hits
             )
 
+        # Process hits and return results
         all_hits_iter = iter(all_hits)
-        if not has_spatial_filter:
-            return process_hits(None, all_hits_iter)
-        else:
-            result = [process_hits(sf, all_hits_iter) for sf in spatial_filter]
-            if spatial_filter_was_list:
-                return result
-            else:
-                return result[0]
+
+        if not isinstance(spatial_filter, list):
+            return process_hits(spatial_filter, all_hits_iter)
+
+        # spatial_filter is a list
+        return [process_hits(sf, all_hits_iter) for sf in spatial_filter]
 
     def get_layout_obj_instance_in_context(self, layout_obj, context):
         """Get the layout object instance of the given :term:`connectable <Connectable>` in the provided context.

--- a/src/ansys/edb/core/layout_instance/layout_instance.py
+++ b/src/ansys/edb/core/layout_instance/layout_instance.py
@@ -103,7 +103,6 @@ class LayoutInstance(ObjBase):
                 **lyt_inst_net_filter_lyr_filter_params
             )
         ]
-        spatial_filter_was_list = isinstance(spatial_filter, list)
         if spatial_filter is not None:
             for sf in utils.ensure_is_list(spatial_filter):
                 requests.append(spatial_filter_to_msg(sf))

--- a/src/ansys/edb/core/layout_instance/layout_instance.py
+++ b/src/ansys/edb/core/layout_instance/layout_instance.py
@@ -104,6 +104,7 @@ class LayoutInstance(ObjBase):
             )
         ]
         has_spatial_filter = spatial_filter is not None
+        spatial_filter_was_list = isinstance(spatial_filter, list)
         if has_spatial_filter:
             spatial_filter = utils.ensure_is_list(spatial_filter)
             for sf in spatial_filter:
@@ -141,10 +142,12 @@ class LayoutInstance(ObjBase):
         all_hits_iter = iter(all_hits)
         if not has_spatial_filter:
             return process_hits(None, all_hits_iter)
-        elif len(spatial_filter) == 1:
-            return process_hits(spatial_filter[0], all_hits_iter)
         else:
-            return [process_hits(sf, all_hits_iter) for sf in spatial_filter]
+            result = [process_hits(sf, all_hits_iter) for sf in spatial_filter]
+            if spatial_filter_was_list:
+                return result
+            else:
+                return result[0]
 
     def get_layout_obj_instance_in_context(self, layout_obj, context):
         """Get the layout object instance of the given :term:`connectable <Connectable>` in the provided context.

--- a/tests/e2e/unit_tests/test_layout_instance.py
+++ b/tests/e2e/unit_tests/test_layout_instance.py
@@ -1,0 +1,34 @@
+import pytest
+
+from ansys.edb.core.geometry.point_data import PointData
+from ansys.edb.core.geometry.polygon_data import PolygonData
+from ansys.edb.core.layout.cell import Cell
+
+
+def test_query_layout_obj_instances(circuit_cell_with_edge_terminals: Cell):
+    loi_list = circuit_cell_with_edge_terminals.layout.layout_instance.query_layout_obj_instances()
+    assert len(loi_list) == 4
+
+
+@pytest.mark.parametrize(
+    ["spatial_filter", "expected_lengths"],
+    [
+        (PointData([0.0, 0.0]), 2),
+        ([PointData([-0.1e-3, 0.0]), PointData([0.1e-3, 0.0])], [2, 2]),
+    ],
+)
+def test_query_layout_obj_instances_spatial_filter(
+    circuit_cell_with_edge_terminals: Cell,
+    expected_lengths: int | list[int],
+    spatial_filter: PolygonData | PointData | None | list[PolygonData | PointData],
+):
+    layout = circuit_cell_with_edge_terminals.layout
+    loi_list = layout.layout_instance.query_layout_obj_instances(
+        spatial_filter=spatial_filter,
+    )
+    if isinstance(expected_lengths, int):
+        assert len(loi_list) == expected_lengths
+    else:
+        assert len(loi_list) == len(expected_lengths)
+        for loi, expected_length in zip(loi_list, expected_lengths):
+            assert len(loi) == expected_length

--- a/tests/e2e/unit_tests/test_layout_instance.py
+++ b/tests/e2e/unit_tests/test_layout_instance.py
@@ -6,14 +6,10 @@ from ansys.edb.core.layout.cell import Cell
 from ansys.edb.core.layout_instance.layout_obj_instance import LayoutObjInstance
 
 
-def test_query_layout_obj_instances(circuit_cell_with_edge_terminals: Cell):
-    loi_list = circuit_cell_with_edge_terminals.layout.layout_instance.query_layout_obj_instances()
-    assert len(loi_list) == 4
-
-
 @pytest.mark.parametrize(
     ["spatial_filter", "expected_lengths"],
     [
+        (None, 4),
         (PointData([0.0, 0.0]), 2),
         ([PointData([0.0, 0.0])], [2]),
         ([PointData([-0.1e-3, 0.0]), PointData([0.1e-3, 0.0])], [2, 2]),

--- a/tests/e2e/unit_tests/test_layout_instance.py
+++ b/tests/e2e/unit_tests/test_layout_instance.py
@@ -15,7 +15,7 @@ from ansys.edb.core.layout_instance.layout_obj_instance import LayoutObjInstance
         ([PointData([-0.1e-3, 0.0]), PointData([0.1e-3, 0.0])], [2, 2]),
     ],
 )
-def test_query_layout_obj_instances_spatial_filter(
+def test_query_layout_obj_instances(
     circuit_cell_with_edge_terminals: Cell,
     expected_lengths: int | list[int],
     spatial_filter: PolygonData | PointData | None | list[PolygonData | PointData],

--- a/tests/e2e/unit_tests/test_layout_instance.py
+++ b/tests/e2e/unit_tests/test_layout_instance.py
@@ -3,6 +3,7 @@ import pytest
 from ansys.edb.core.geometry.point_data import PointData
 from ansys.edb.core.geometry.polygon_data import PolygonData
 from ansys.edb.core.layout.cell import Cell
+from ansys.edb.core.layout_instance.layout_obj_instance import LayoutObjInstance
 
 
 def test_query_layout_obj_instances(circuit_cell_with_edge_terminals: Cell):
@@ -14,6 +15,7 @@ def test_query_layout_obj_instances(circuit_cell_with_edge_terminals: Cell):
     ["spatial_filter", "expected_lengths"],
     [
         (PointData([0.0, 0.0]), 2),
+        ([PointData([0.0, 0.0])], [2]),
         ([PointData([-0.1e-3, 0.0]), PointData([0.1e-3, 0.0])], [2, 2]),
     ],
 )
@@ -28,7 +30,10 @@ def test_query_layout_obj_instances_spatial_filter(
     )
     if isinstance(expected_lengths, int):
         assert len(loi_list) == expected_lengths
+        assert all(isinstance(loi, LayoutObjInstance) for loi in loi_list)
     else:
         assert len(loi_list) == len(expected_lengths)
-        for loi, expected_length in zip(loi_list, expected_lengths):
-            assert len(loi) == expected_length
+        for loi_result, expected_length in zip(loi_list, expected_lengths):
+            assert isinstance(loi_result, list)
+            assert len(loi_result) == expected_length
+            assert all(isinstance(loi, LayoutObjInstance) for loi in loi_result)

--- a/tests/mock/test_layout_instance.py
+++ b/tests/mock/test_layout_instance.py
@@ -1,0 +1,129 @@
+from types import SimpleNamespace
+
+from ansys.api.edb.v1.edb_messages_pb2 import EDBObjMessage
+import pytest
+from utils.fixtures import *  # noqa
+
+from ansys.edb.core.geometry.point_data import PointData
+from ansys.edb.core.geometry.polygon_data import PolygonData
+import ansys.edb.core.layout_instance.layout_instance as layout_instance_mod
+from ansys.edb.core.layout_instance.layout_obj_instance import LayoutObjInstance
+
+
+@pytest.fixture
+def layout_instance(edb_obj_msg):
+    return layout_instance_mod.LayoutInstance(edb_obj_msg)
+
+
+def _hit(edb_obj_id, is_group_end=False):
+    return SimpleNamespace(
+        edb_obj=EDBObjMessage(id=edb_obj_id),
+        is_partial=False,
+        is_end_of_query_results_group=is_group_end,
+    )
+
+
+def _group(start_id, count):
+    hits = [_hit(start_id + i) for i in range(count)]
+    hits.append(_hit(0, is_group_end=True))
+    return hits
+
+
+def _hits_for_spatial_filter(spatial_filter):
+    if spatial_filter is None:
+        return _group(1, 4)
+    if isinstance(spatial_filter, PointData):
+        return _group(101, 2)
+    if isinstance(spatial_filter, list):
+        all_hits = []
+        start_id = 201
+        for _ in spatial_filter:
+            all_hits.extend(_group(start_id, 2))
+            start_id += 10
+        return all_hits
+    raise ValueError("Unsupported spatial filter fixture value")
+
+
+@pytest.mark.parametrize(
+    ["spatial_filter", "expected_lengths"],
+    [
+        (None, 4),
+        (PointData([0.0, 0.0]), 2),
+        ([PointData([0.0, 0.0])], [2]),
+        ([PointData([-0.1e-3, 0.0]), PointData([0.1e-3, 0.0])], [2, 2]),
+    ],
+)
+def test_query_layout_obj_instances(
+    mocker,
+    mocked_stub,
+    layout_instance,
+    expected_lengths: int | list[int],
+    spatial_filter: PolygonData | PointData | None | list[PolygonData | PointData],
+):
+    mocker.patch("ansys.edb.core.layout_instance.layout_instance.is_in_memory", return_value=True)
+    stub = mocked_stub(layout_instance_mod, layout_instance_mod.LayoutInstance)
+    stub.BatchQueryLayoutObjInstances.return_value = SimpleNamespace(
+        query_results=_hits_for_spatial_filter(spatial_filter)
+    )
+
+    loi_list = layout_instance.query_layout_obj_instances(spatial_filter=spatial_filter)
+
+    stub.BatchQueryLayoutObjInstances.assert_called_once()
+    stub.StreamLayoutObjInstancesQuery.assert_not_called()
+
+    assert_loi_list(loi_list, expected_lengths)
+
+
+@pytest.mark.parametrize(
+    ["spatial_filter", "expected_lengths"],
+    [
+        (None, 4),
+        (PointData([0.0, 0.0]), 2),
+        ([PointData([0.0, 0.0])], [2]),
+        ([PointData([-0.1e-3, 0.0]), PointData([0.1e-3, 0.0])], [2, 2]),
+    ],
+)
+def test_query_layout_obj_instances_stream_path(
+    mocker,
+    mocked_stub,
+    layout_instance,
+    expected_lengths: int | list[int],
+    spatial_filter: PolygonData | PointData | None | list[PolygonData | PointData],
+):
+    mocker.patch("ansys.edb.core.layout_instance.layout_instance.is_in_memory", return_value=False)
+    stub = mocked_stub(layout_instance_mod, layout_instance_mod.LayoutInstance)
+    all_hits = _hits_for_spatial_filter(spatial_filter)
+    stub.StreamLayoutObjInstancesQuery.return_value = [SimpleNamespace(query_results=all_hits)]
+
+    loi_list = layout_instance.query_layout_obj_instances(spatial_filter=spatial_filter)
+
+    stub.BatchQueryLayoutObjInstances.assert_not_called()
+    stub.StreamLayoutObjInstancesQuery.assert_called_once()
+
+    assert_loi_list(loi_list, expected_lengths)
+
+
+def assert_loi_list(
+    loi_list: list[LayoutObjInstance | list[LayoutObjInstance]], expected_lengths: int | list[int]
+):
+    """Assert that the given list of layout object instances matches the expected lengths and types.
+
+    Parameters
+    ----------
+    loi_list : list[LayoutObjInstance | list[LayoutObjInstance]]
+        List of layout object instances to check, as returned by :func:`LayoutInstance.query_layout_obj_instances()`.
+        Can be a list of layout object instances or a list of lists of layout object instances, depending on whether the
+        spatial filter provided to the query was a list.
+    expected_lengths : int | list[int]
+        The expected length(s) of the list(s) of layout object instances. Can be a single integer if the query was made
+        with a non-list spatial filter, or a list of integers if the query was made with a list spatial filter.
+    """
+    if isinstance(expected_lengths, int):
+        assert len(loi_list) == expected_lengths
+        assert all(isinstance(loi, LayoutObjInstance) for loi in loi_list)
+    else:
+        assert len(loi_list) == len(expected_lengths)
+        for loi_result, expected_length in zip(loi_list, expected_lengths):
+            assert isinstance(loi_result, list)
+            assert len(loi_result) == expected_length
+            assert all(isinstance(loi, LayoutObjInstance) for loi in loi_result)


### PR DESCRIPTION
Fix an undeclared variable reference in `query_layout_obj_instances` and add a test ensure it works at least with either a `PointData` or list of two `PointData` as the `spatial_filter` argument.

Fixes #757 