### PR TITLE
CI: add `BUILD` to the pull request title template

### DIFF
--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run a PR title validation
-        run: grep -E "^(CI:|DOC:|REFACT:|FIX:|MAINT:|TEST:|FEATURE:)" <<< "${{ github.event.pull_request.title }}"
+        run: grep -E "^(CI:|DOC:|REFACT:|FIX:|MAINT:|TEST:|FEATURE:|BUILD:)" <<< "${{ github.event.pull_request.title }}"

--- a/.github/workflows/template.yml
+++ b/.github/workflows/template.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run a PR title validation
-        run: grep -E "^(CI:|DOC:|REFACT:|FIX:|MAINT:|TEST:|FEATURE:|BUILD:)" <<< "${{ github.event.pull_request.title }}"
+        run: grep -E "^(CI|DOC|REFACT|FIX|MAINT|TEST|FEATURE|BUILD)(\([^)]*\))?:" <<< "${{ github.event.pull_request.title }}"


### PR DESCRIPTION
In the future, incorporating the PR title action from [ansys-actions](https://actions.docs.ansys.com/version/stable/style-actions/index.html#pull-request-title-action) could improve reusability in this context.